### PR TITLE
Add violations for Lists.newCopyOnWriteArrayList() and Maps.newConcurrentMap()

### DIFF
--- a/src/main/resources/modernizer.xml
+++ b/src/main/resources/modernizer.xml
@@ -103,9 +103,21 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>com/google/common/collect/Lists.newCopyOnWriteArrayList:()Ljava/util/concurrent/CopyOnWriteArrayList;</name>
+    <version>1.7</version>
+    <comment>Prefer java.util.concurrent.CopyOnWriteArrayList&lt;&gt;()</comment>
+  </violation>
+
+  <violation>
     <name>com/google/common/collect/Lists.newLinkedList:()Ljava/util/LinkedList;</name>
     <version>1.7</version>
     <comment>Prefer java.util.LinkedList&lt;&gt;()</comment>
+  </violation>
+
+  <violation>
+    <name>com/google/common/collect/Maps.newConcurrentMap:()Ljava/util/concurrent/ConcurrentMap;</name>
+    <version>1.7</version>
+    <comment>Prefer java.util.concurrent.ConcurrentHashMap&lt;&gt;() or customize the map using com.google.common.collect.MapMaker</comment>
   </violation>
 
   <violation>

--- a/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -267,7 +267,9 @@ public final class ModernizerTest {
             Optional.fromNullable(null);
             Lists.newArrayList();
             Lists.newArrayListWithCapacity(0);
+            Lists.newCopyOnWriteArrayList();
             Lists.newLinkedList();
+            Maps.newConcurrentMap();
             Maps.newEnumMap((Class<EnumClass>) null);
             Maps.newEnumMap((Map<EnumClass, Object>) null);
             Maps.newHashMap();


### PR DESCRIPTION
Summary says it. Consideration mentioned in the commit message:

> Note that the behavior of `Maps.newConcurrentMap()` is slightly different from `new ConcurrentHashMap<>()`: with Guava 18.0 the former creates a map with a concurrency level of 4, whereas the latter uses concurrency level 16. Most users will not care, and those that do should make this intention explicit. (This is one of the reasons that the JavaDoc for Maps.newConcurrentMap points to MapMaker.)
