### PR TITLE
Don't fork for the plugin execution

### DIFF
--- a/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
+++ b/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
@@ -30,15 +30,14 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.xml.sax.SAXException;
 
-@Mojo(name = "modernizer")
-@Execute(phase = LifecyclePhase.PROCESS_TEST_CLASSES)
+@Mojo(name = "modernizer", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES,
+      threadSafe = true)
 public final class ModernizerMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;


### PR DESCRIPTION
The plugin's execution currently happens in a forked process. Not a big deal by itself, but it's not strictly necessary, and a side effect of the current setup is that it causes all build steps up to the process-test-classes phase to be executed twice. That's wasteful, and can be expensive depending on the project. (I have a project here that runs the `checker-framework` just before the `modernizer` plugin, and that's a heavy operation.)

An additional benefit of this change is that it no longer causes the plugin the fail on (sub)modules without tests. (For some reason it currently forces execution of Surefire, which then fails because neither JUnit nor TestNG are on the classpath of such test-less modules. This could be an obscure side effect of my project's setup, but still.)
