### PR TITLE
Use process-test-classes phase in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ The `<configuration>` stanza can contain several elements:
 * `<exclusionsFile>` disables user-specified violations.  This is a text file with one exclusion per line in the javap format: `java/lang/String.getBytes:(Ljava/lang/String;)[B`.
 * `<ignorePackages>` package prefixes to ignore, specified using `<ignorePackage>` child elements. Specifying `foo.bar` subsequently ignores `foo.bar.*`, `foo.bar.baz.*` and so on.
 
-To run Modernizer during the verify phase of your build, add the following to
+To run Modernizer during the `process-test-classes` phase of your build, add the following to
 the modernizer `<plugin>` stanza in your pom.xml:
 
 ```xml
 <executions>
   <execution>
     <id>modernizer</id>
-    <phase>verify</phase>
+    <phase>process-test-classes</phase>
     <goals>
       <goal>modernizer</goal>
     </goals>


### PR DESCRIPTION
There should be no need for the user so sit through the tests before reaching the `validate` stage if the build should fail due to using legacy APIs.

`process-test-classes` makes the most sense because it's the first phase after all classes have been compiled, and works regardless of `includeTestClasses` value.
