### PR TITLE
#61 Prefer ThreadLocalRandom over Random

### DIFF
--- a/src/main/resources/modernizer.xml
+++ b/src/main/resources/modernizer.xml
@@ -661,6 +661,18 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>java/util/Random."&lt;init&gt;":()V</name>
+    <version>1.7</version>
+    <comment>Prefer java.util.ThreadLocalRandom.current()</comment>
+  </violation>
+
+  <violation>
+    <name>java/util/Random."&lt;init&gt;":(J)V</name>
+    <version>1.7</version>
+    <comment>Prefer java.util.ThreadLocalRandom.current()</comment>
+  </violation>
+
+  <violation>
     <name>java/util/Vector."&lt;init&gt;":()V</name>
     <version>1.2</version>
     <comment>Prefer java.util.ArrayList</comment>

--- a/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -32,8 +32,10 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Random;
 import java.util.SortedMap;
 import java.util.Vector;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Charsets;
@@ -609,6 +611,8 @@ public final class ModernizerTest {
             object = Collections.EMPTY_LIST;
             object = Collections.EMPTY_MAP;
             object = Collections.EMPTY_SET;
+            object = new Random();
+            object = new Random(50L);
         }
     }
 

--- a/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.SortedMap;
 import java.util.Vector;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Charsets;


### PR DESCRIPTION
Adding violation for `new Random()` and `new Random(long)` to prefer the more modern `ThreadLocalRandom.current()`