### PR TITLE
Allow comments in exclusion file

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `<configuration>` stanza can contain several elements:
 * `<includeTestClasses>` run Modernizer on test classes.  Defaults to true.
 * `<violationsFile>` user-specified violation file.  Also disables standard violation checks. Can point to classpath using absolute paths, e.g. `classpath:/your/file.xml`.
 * `<violationsFiles>` user-specified violations file.  The latter files override violations from the former ones, including `violationsFile` and the default violations. Can point to classpath using absolute paths, e.g. `classpath:/your/file.xml`.
-* `<exclusionsFile>` disables user-specified violations.  This is a text file with one exclusion per line in the javap format: `java/lang/String.getBytes:(Ljava/lang/String;)[B`.
+* `<exclusionsFile>` disables user-specified violations.  This is a text file with one exclusion per line in the javap format: `java/lang/String.getBytes:(Ljava/lang/String;)[B`.  Empty lines and lines starting with `#` are ignored.
 * `<exclusions>` violations to disable. Each exclusion should be in the javap format: `java/lang/String.getBytes:(Ljava/lang/String;)[B`.
 * `<exclusionPatterns>` violation patterns to disable, specified using `<exclusionPattern>` child elements. Each exclusion should be a regular expression that matches the javap format: `java/lang/.*` of a violation.
 * `<ignorePackages>` package prefixes to ignore, specified using `<ignorePackage>` child elements. Specifying `foo.bar` subsequently ignores `foo.bar.*`, `foo.bar.baz.*` and so on.

--- a/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
+++ b/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
@@ -282,7 +282,7 @@ public final class ModernizerMojo extends AbstractMojo {
                         exclusionsFilePath);
             }
 
-            return Utils.readAllLines(is);
+            return Utils.filterCommentLines(Utils.readAllLines(is));
         } catch (IOException ioe) {
             throw new MojoExecutionException(
                     "Error reading exclusion file: " +

--- a/src/main/java/org/gaul/modernizer_maven_plugin/Utils.java
+++ b/src/main/java/org/gaul/modernizer_maven_plugin/Utils.java
@@ -85,6 +85,18 @@ final class Utils {
         return lines;
     }
 
+    static Collection<String> filterCommentLines(Collection<String> lines) {
+        Collection<String> result = new ArrayList<String>();
+        for (String line : lines) {
+            String trimmedLine = line.trim();
+            if (trimmedLine.isEmpty() || trimmedLine.startsWith("#")) {
+                continue;
+            }
+            result.add(line);
+        }
+        return result;
+    }
+
     private Utils() {
         throw new AssertionError("Intentionally not implemented");
     }

--- a/src/test/java/org/gaul/modernizer_maven_plugin/UtilsTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/UtilsTest.java
@@ -1,18 +1,36 @@
+/*
+ * Copyright 2014-2018 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.gaul.modernizer_maven_plugin;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 
 public class UtilsTest {
 
     @Test
-    public void testFilterComments() {
-        Collection<String> lines = Arrays.asList("foo", "", " # comment", " bar ");
-        assertEquals(Arrays.asList("foo", " bar "), Utils.filterCommentLines(lines));
+    public final void testFilterComments() {
+        Collection<String> lines = Arrays.asList(
+                "foo", "", " # comment", " bar ");
+        assertEquals(Arrays.asList("foo", " bar "),
+                Utils.filterCommentLines(lines));
     }
 }

--- a/src/test/java/org/gaul/modernizer_maven_plugin/UtilsTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/UtilsTest.java
@@ -1,0 +1,18 @@
+package org.gaul.modernizer_maven_plugin;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class UtilsTest {
+
+    @Test
+    public void testFilterComments() {
+        Collection<String> lines = Arrays.asList("foo", "", " # comment", " bar ");
+        assertEquals(Arrays.asList("foo", " bar "), Utils.filterCommentLines(lines));
+    }
+}


### PR DESCRIPTION
Empty lines and lines starting with `#` will be ignored.

Fixes #27