### PR TITLE
Add violations for Guava NavigableMap/Set methods

### DIFF
--- a/src/main/resources/modernizer.xml
+++ b/src/main/resources/modernizer.xml
@@ -337,6 +337,18 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>com/google/common/collect/Maps.unmodifiableNavigableMap:(Ljava/util/NavigableMap;)Ljava/util/NavigableMap;</name>
+    <version>1.8</version>
+    <comment>Prefer java.util.Collections.unmodifiableNavigableMap&lt;&gt;(java.util.NavigableMap)</comment>
+  </violation>
+
+  <violation>
+    <name>com/google/common/collect/Maps.synchronizedNavigableMap:(Ljava/util/NavigableMap;)Ljava/util/NavigableMap;</name>
+    <version>1.8</version>
+    <comment>Prefer java.util.Collections.synchronizedNavigableMap&lt;&gt;(java.util.NavigableMap)</comment>
+  </violation>
+
+  <violation>
     <name>com/google/common/collect/Sets.newCopyOnWriteArraySet:()Ljava/util/concurrent/CopyOnWriteArraySet;</name>
     <version>1.7</version>
     <comment>Prefer java.util.concurrent.CopyOnWriteArraySet&lt;&gt;()</comment>
@@ -370,6 +382,18 @@ violation names use the same format that javap emits.
     <name>com/google/common/collect/Sets.newTreeSet:(Ljava/util/Comparator;)Ljava/util/TreeSet;</name>
     <version>1.7</version>
     <comment>Prefer java.util.TreeSet&lt;&gt;(java.util.Comparator)</comment>
+  </violation>
+
+  <violation>
+    <name>com/google/common/collect/Sets.unmodifiableNavigableSet:(Ljava/util/NavigableSet;)Ljava/util/NavigableSet;</name>
+    <version>1.8</version>
+    <comment>Prefer java.util.Collections.unmodifiableNavigableSet&lt;&gt;(java.util.NavigableSet)</comment>
+  </violation>
+
+  <violation>
+    <name>com/google/common/collect/Sets.synchronizedNavigableSet:(Ljava/util/NavigableSet;)Ljava/util/NavigableSet;</name>
+    <version>1.8</version>
+    <comment>Prefer java.util.Collections.synchronizedNavigableSet&lt;&gt;(java.util.NavigableSet)</comment>
   </violation>
 
   <violation>

--- a/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -45,6 +45,8 @@ import java.util.Map;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.Vector;
 import java.util.regex.Pattern;
 
@@ -546,12 +548,16 @@ public final class ModernizerTest {
             Maps.newTreeMap();
             Maps.newTreeMap((Comparator<Object>) null);
             Maps.newTreeMap((SortedMap<Object, Object>) null);
+            Maps.unmodifiableNavigableMap(new TreeMap<Object, Object>());
+            Maps.synchronizedNavigableMap(new TreeMap<Object, Object>());
             Sets.newCopyOnWriteArraySet();
             Sets.newHashSet();
             Sets.newLinkedHashSet();
             Sets.newSetFromMap((Map<Object, Boolean>) null);
             Sets.newTreeSet();
             Sets.newTreeSet((Comparator<Object>) null);
+            Sets.unmodifiableNavigableSet(new TreeSet<Object>());
+            Sets.synchronizedNavigableSet(new TreeSet<Object>());
             BaseEncoding.base64();
             ByteStreams.copy((InputStream) null, (OutputStream) null);
             Files.toByteArray((File) null);


### PR DESCRIPTION
Since Java 8 there are java.util.Collections alternatives for
* unmodifiableNavigableMap
* synchronizedNavigableMap
* unmodifiableNavigableSet
* synchronizedNavigableSet