### PR TITLE
Add Automatic-Module-Name header

### DIFF
--- a/modernizer-maven-annotations/pom.xml
+++ b/modernizer-maven-annotations/pom.xml
@@ -25,6 +25,16 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries combine.children="append">
+              <Automatic-Module-Name>org.gaul.modernizer_maven_annotations</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This names modernizer-maven-annotations, so it can be used as
a dependency in JMPS. This fixes #93.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>