### PR TITLE
Add JPMS module-info

### DIFF
--- a/modernizer-maven-annotations/pom.xml
+++ b/modernizer-maven-annotations/pom.xml
@@ -26,11 +26,29 @@
         </dependencies>
       </plugin>
       <plugin>
+        <groupId>codes.rafael.modulemaker</groupId>
+        <artifactId>modulemaker-maven-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>inject-module</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <name>org.gaul.modernizer_maven_annotations</name>
+          <exports>org.gaul.modernizer_maven_annotations</exports>
+          <multirelease>true</multirelease>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
             <manifestEntries combine.children="append">
-              <Automatic-Module-Name>org.gaul.modernizer_maven_annotations</Automatic-Module-Name>
+              <Multi-Release>true</Multi-Release>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
This patch uses a combination of modulemaker-maven-plugin and
multi-release jar (JEP-238) to make modernizer-maven-annotations
a full JPMS module. For older JVM versions there is no impact,
as the class is not visible there.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>