### PR TITLE
Ignore classes annotated with `@Generated` #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The `<configuration>` stanza can contain several elements:
 * `<exclusionPatterns>` violation patterns to disable, specified using `<exclusionPattern>` child elements. Each exclusion should be a regular expression that matches the javap format: `java/lang/.*` of a violation.
 * `<ignorePackages>` package prefixes to ignore, specified using `<ignorePackage>` child elements. Specifying `foo.bar` subsequently ignores `foo.bar.*`, `foo.bar.baz.*` and so on.
 * `<ignoreClassNamePatterns>` full qualified class names (incl. package) to ignore, specified using `<ignoreClassNamePattern>` child elements. Each exclusion should be a regular expression that matches a package and/or class; the package will be / not . separated (ASM's format).
+* `<ignoreGeneratedClasses>` classes annotated with annotations that contain "Generated" in their name will be ignored.
 
 To run Modernizer during the verify phase of your build, add the following to
 the modernizer `<plugin>` stanza in your pom.xml:

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -113,6 +115,36 @@
             <version>${project.version}</version>
           </dependency>
         </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <mavenOpts>${argLine}</mavenOpts>
+          <debug>true</debug>
+          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+          <pomIncludes>
+            <pomInclude>*/pom.xml</pomInclude>
+          </pomIncludes>
+          <postBuildHookScript>verify</postBuildHookScript>
+          <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+          <settingsFile>src/it/settings.xml</settingsFile>
+          <goals>
+            <goal>clean</goal>
+            <goal>test-compile</goal>
+          </goals>
+        </configuration>
+        <executions>
+          <execution>
+            <id>integration-test</id>
+            <goals>
+              <goal>install</goal>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/modernizer-maven-plugin/src/it/issue-28-option-disabled/invoker.properties
+++ b/modernizer-maven-plugin/src/it/issue-28-option-disabled/invoker.properties
@@ -1,0 +1,15 @@
+# Copyright 2014-2019 Andrew Gaul <andrew@gaul.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals=verify

--- a/modernizer-maven-plugin/src/it/issue-28-option-disabled/pom.xml
+++ b/modernizer-maven-plugin/src/it/issue-28-option-disabled/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.gaul.it</groupId>
+	<artifactId>ignores-generated-classes</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.6</maven.compiler.source>
+		<maven.compiler.target>1.6</maven.compiler.target>
+		<modernizer.javaVersion>1.6</modernizer.javaVersion>
+		<modernizer.ignoreGeneratedClasses>false</modernizer.ignoreGeneratedClasses>
+		<modernizer.failOnViolations>false</modernizer.failOnViolations>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>modernizer</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>modernizer</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/modernizer-maven-plugin/src/it/issue-28-option-disabled/src/main/java/org/gaul/it/Generated.java
+++ b/modernizer-maven-plugin/src/it/issue-28-option-disabled/src/main/java/org/gaul/it/Generated.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2019 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.it;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(CLASS)
+@Target(TYPE)
+public @interface Generated {}

--- a/modernizer-maven-plugin/src/it/issue-28-option-disabled/src/main/java/org/gaul/it/TestClass.java
+++ b/modernizer-maven-plugin/src/it/issue-28-option-disabled/src/main/java/org/gaul/it/TestClass.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2019 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.it;
+
+import java.util.Set;
+import java.util.Vector;
+
+@Generated
+public class TestClass {
+	public Vector<String> getSet() {
+		return new Vector<String>();
+	}
+}

--- a/modernizer-maven-plugin/src/it/issue-28-option-disabled/verify.groovy
+++ b/modernizer-maven-plugin/src/it/issue-28-option-disabled/verify.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2014-2019 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+log = new File(basedir, 'build.log')
+assert log.text.contains('/src/main/java/org/gaul/it/TestClass.java:25: Prefer java.util.ArrayList')

--- a/modernizer-maven-plugin/src/it/issue-28-option-enabled/invoker.properties
+++ b/modernizer-maven-plugin/src/it/issue-28-option-enabled/invoker.properties
@@ -1,0 +1,15 @@
+# Copyright 2014-2019 Andrew Gaul <andrew@gaul.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+invoker.goals=verify

--- a/modernizer-maven-plugin/src/it/issue-28-option-enabled/pom.xml
+++ b/modernizer-maven-plugin/src/it/issue-28-option-enabled/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.gaul.it</groupId>
+	<artifactId>ignores-generated-classes</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.6</maven.compiler.source>
+		<maven.compiler.target>1.6</maven.compiler.target>
+		<modernizer.javaVersion>1.6</modernizer.javaVersion>
+		<modernizer.ignoreGeneratedClasses>true</modernizer.ignoreGeneratedClasses>
+		<modernizer.failOnViolations>true</modernizer.failOnViolations>
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>modernizer</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>modernizer</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/modernizer-maven-plugin/src/it/issue-28-option-enabled/src/main/java/org/gaul/it/Generated.java
+++ b/modernizer-maven-plugin/src/it/issue-28-option-enabled/src/main/java/org/gaul/it/Generated.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014-2019 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.it;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(CLASS)
+@Target(TYPE)
+public @interface Generated {}

--- a/modernizer-maven-plugin/src/it/issue-28-option-enabled/src/main/java/org/gaul/it/TestClass.java
+++ b/modernizer-maven-plugin/src/it/issue-28-option-enabled/src/main/java/org/gaul/it/TestClass.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014-2019 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.it;
+
+import java.util.Set;
+import java.util.Vector;
+
+@Generated
+public class TestClass {
+	public Vector<String> getSet() {
+		return new Vector<String>();
+	}
+}

--- a/modernizer-maven-plugin/src/it/settings.xml
+++ b/modernizer-maven-plugin/src/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
@@ -131,6 +131,14 @@ public final class ModernizerMojo extends AbstractMojo {
     private String violationLogLevel;
 
     /**
+     * Classes annotated with {@code @Generated} will be excluded from
+     * scanning.
+     * */
+    @Parameter(defaultValue = "true",
+               property = "modernizer.ignoreGeneratedClasses")
+    private Boolean ignoreGeneratedClasses;
+
+    /**
      * Violations to disable. Each exclusion should be in the javap format:
      *
      * java/lang/String.getBytes:(Ljava/lang/String;)[B.
@@ -222,10 +230,37 @@ public final class ModernizerMojo extends AbstractMojo {
         try {
             ignoreClassNames.addAll(
                 SuppressModernizerAnnotationDetector.detect(outputDirectory));
+            if (ignoreGeneratedClasses) {
+                Set<String> ignore =
+                    SuppressGeneratedAnnotationDetector.detect(
+                        outputDirectory);
+                if (getLog().isDebugEnabled()) {
+                    getLog().debug(
+                        "The following generated classes will be ignored");
+                    for (String s : ignore) {
+                        getLog().debug(s);
+                    }
+                }
+                ignoreClassNames.addAll(ignore);
+            }
             if (includeTestClasses) {
                 ignoreClassNames.addAll(
                     SuppressModernizerAnnotationDetector.detect(
                         testOutputDirectory));
+                if (ignoreGeneratedClasses) {
+                    Set<String> ignore =
+                        SuppressGeneratedAnnotationDetector.detect(
+                            testOutputDirectory);
+                    if (getLog().isDebugEnabled()) {
+                        getLog().debug(
+                            "The following generated test classes " +
+                            "will be ignored");
+                        for (String s : ignore) {
+                            getLog().debug(s);
+                        }
+                    }
+                    ignoreClassNames.addAll(ignore);
+                }
             }
         } catch (IOException e) {
             throw new MojoExecutionException("Error reading suppressions", e);

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/SuppressGeneratedAnnotationDetector.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/SuppressGeneratedAnnotationDetector.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014-2019 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.modernizer_maven_plugin;
+
+import static org.gaul.modernizer_maven_plugin.Utils.ASM_API;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+
+public final class SuppressGeneratedAnnotationDetector {
+    private final Set<String> annotatedClassNames =
+        new HashSet<String>();
+    private final Set<String> allClassNames =
+        new HashSet<String>();
+
+    private SuppressGeneratedAnnotationDetector() { }
+
+    public static Set<String> detect(File file) throws IOException {
+        SuppressGeneratedAnnotationDetector detector =
+            new SuppressGeneratedAnnotationDetector();
+        detector.detectInternal(file);
+        return detector.computeSuppressedClassNames();
+    }
+
+    private Set<String> computeSuppressedClassNames() {
+        Set<String> suppressedClassNames =
+            new HashSet<String>(annotatedClassNames);
+        for (String className : allClassNames) {
+            if (suppressedClassNames.contains(className)) {
+                continue;
+            }
+            int fromIndex = 0;
+            while (true) {
+                int index = className.indexOf('$', fromIndex);
+                if (index == -1) {
+                    break;
+                }
+                boolean outerSuppressed =
+                    annotatedClassNames.contains(className.substring(0, index));
+                if (outerSuppressed) {
+                    suppressedClassNames.add(className);
+                    break;
+                }
+                fromIndex = index + 1;
+            }
+        }
+        return suppressedClassNames;
+    }
+
+    private void detectInternal(File file) throws IOException {
+        if (!file.exists()) {
+            return;
+        } else if (file.isDirectory()) {
+            String[] children = file.list();
+            if (children != null) {
+                for (String child : children) {
+                    detectInternal(new File(file, child));
+                }
+            }
+        } else if (file.getPath().endsWith(".class")) {
+            InputStream inputStream = null;
+            try {
+                inputStream = new FileInputStream(file);
+                detectInternal(new ClassReader(inputStream));
+            } finally {
+                Utils.closeQuietly(inputStream);
+            }
+        }
+    }
+
+    private void detectInternal(ClassReader classReader) {
+        classReader.accept(new Visitor(), 0);
+    }
+
+    private final class Visitor extends ClassVisitor {
+        private String className;
+
+        Visitor() {
+            super(ASM_API);
+        }
+
+        @Override
+        public void visit(int version, int access, String name,
+                          String signature, String superName,
+                          String[] interfaces) {
+            this.className = name;
+            allClassNames.add(className);
+            super.visit(version, access, name,
+                        signature, superName,
+                        interfaces);
+        }
+
+        @Override
+        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+            final String name = desc.substring(Math.max(desc.lastIndexOf('/'),
+                    desc.lastIndexOf('$')) + 1);
+            boolean isGenerated = name.contains("Generated");
+            if (isGenerated) {
+                annotatedClassNames.add(className);
+            }
+            return super.visitAnnotation(desc, visible);
+        }
+    }
+}


### PR DESCRIPTION
Provide an implementation for #28.

This is a rather dirty implementation. Based on the already existing suppression filter. There is a lot of duplicated code right now and no test.

Should this PR be improved or can it be accepted as is?

Improving this PR would probably take some time. I have some ideas, but I would like to check them with you first @gaul. Maybe lets split this. Accept the PR as is and open an issue to track the cleanup and missing test.