### PR TITLE
Don't suggest java.io.InputStream.skipNBytes(long) before JDK 12

### DIFF
--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1100,7 +1100,7 @@ violation names use the same format that javap emits.
 
   <violation>
     <name>com/google/common/io/ByteStreams.skipFully:(Ljava/io/InputStream;J)V</name>
-    <version>1.11</version>
+    <version>1.12</version>
     <comment>Prefer java.io.InputStream.skipNBytes(long)</comment>
   </violation>
 

--- a/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -384,13 +384,15 @@ public final class ModernizerTest {
 
     @Test
     public void testAllViolations() throws Exception {
-        Modernizer modernizer = createModernizer("1.11");
+        Modernizer modernizer = createModernizer("1.12");
         Collection<ViolationOccurrence> occurrences = modernizer.check(
                 new ClassReader(AllViolations.class.getName()));
         occurrences.addAll(modernizer.check(
                 new ClassReader(Java10Violations.class.getName())));
         occurrences.addAll(modernizer.check(
                 new ClassReader(Java11Violations.class.getName())));
+        occurrences.addAll(modernizer.check(
+                new ClassReader(Java12Violations.class.getName())));
         // must visit inner classes manually
         occurrences.addAll(modernizer.check(
                 new ClassReader(VoidFunction.class.getName())));
@@ -751,7 +753,6 @@ public final class ModernizerTest {
     private static class Java11Violations {
         private static void method() throws Exception {
             ByteStreams.nullOutputStream();
-            ByteStreams.skipFully(null, 0L);
             CharStreams.nullWriter();
             Files.toString((File) null, (Charset) null);
             Files.write("", (File) null, (Charset) null);
@@ -761,6 +762,12 @@ public final class ModernizerTest {
             new FileWriter((File) null, true);
             new FileWriter("");
             new FileWriter("", true);
+        }
+    }
+
+    private static class Java12Violations {
+        private static void method() throws Exception {
+            ByteStreams.skipFully(null, 0L);
         }
     }
 


### PR DESCRIPTION
Compare [JDK 11](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/io/InputStream.html) and [JDK 12](https://docs.oracle.com/en/java/javase/12/docs/api/java.base/java/io/InputStream.html).