### PR TITLE
Build fixes, jdk support through 15, raise to jdk 7 requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: java
 jdk:
+  - openjdk15
+  - openjdk14
+  - openjdk11
   - openjdk8

--- a/modernizer-maven-plugin/src/it/issue-28-option-disabled/pom.xml
+++ b/modernizer-maven-plugin/src/it/issue-28-option-disabled/pom.xml
@@ -10,15 +10,20 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
-		<modernizer.javaVersion>1.6</modernizer.javaVersion>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
+		<modernizer.javaVersion>1.7</modernizer.javaVersion>
 		<modernizer.ignoreGeneratedClasses>false</modernizer.ignoreGeneratedClasses>
 		<modernizer.failOnViolations>false</modernizer.failOnViolations>
 	</properties>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.6.1</version>
+			</plugin>
 			<plugin>
 				<groupId>@project.groupId@</groupId>
 				<artifactId>@project.artifactId@</artifactId>

--- a/modernizer-maven-plugin/src/it/issue-28-option-enabled/pom.xml
+++ b/modernizer-maven-plugin/src/it/issue-28-option-enabled/pom.xml
@@ -10,15 +10,20 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
-		<modernizer.javaVersion>1.6</modernizer.javaVersion>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
+		<modernizer.javaVersion>1.7</modernizer.javaVersion>
 		<modernizer.ignoreGeneratedClasses>true</modernizer.ignoreGeneratedClasses>
 		<modernizer.failOnViolations>true</modernizer.failOnViolations>
 	</properties>
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.6.1</version>
+			</plugin>
 			<plugin>
 				<groupId>@project.groupId@</groupId>
 				<artifactId>@project.artifactId@</artifactId>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -811,18 +811,6 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
-    <name>sun/misc/BASE64Decoder.decodeBuffer:(Ljava/lang/String;)[B</name>
-    <version>1.8</version>
-    <comment>Prefer java.util.Base64.Decoder.decode(String)</comment>
-  </violation>
-
-  <violation>
-    <name>sun/misc/BASE64Encoder.encode:([B)Ljava/lang/String;</name>
-    <version>1.8</version>
-    <comment>Prefer java.util.Base64.Encoder.encodeToString(byte[])</comment>
-  </violation>
-
-  <violation>
     <name>com/google/common/base/Preconditions.checkNotNull:(Ljava/lang/Object;)Ljava/lang/Object;</name>
     <version>1.7</version>
     <comment>Prefer java.util.Objects.requireNonNull(Object)</comment>

--- a/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -107,9 +107,6 @@ import org.junit.Test;
 import org.objectweb.asm.ClassReader;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import sun.misc.BASE64Decoder;
-import sun.misc.BASE64Encoder;
-
 public final class ModernizerTest {
     private Map<String, Violation> violations;
     private static final Collection<String> NO_EXCLUSIONS =
@@ -695,8 +692,8 @@ public final class ModernizerTest {
             FileUtils.readLines((File) null);
             FileUtils.readLines((File) null, (Charset) null);
             FileUtils.readLines((File) null, "");
-            new BASE64Decoder().decodeBuffer("");
-            new BASE64Encoder().encode((byte[]) null);
+            Base64.decodeBase64("");
+            Base64.encodeBase64((byte[]) null);
             Preconditions.checkNotNull(new Object());
             Preconditions.checkNotNull(new Object(), new Object());
             Preconditions.checkElementIndex(0, 0);

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.6.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <compilerArguments>
@@ -247,6 +245,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <asm.version>8.0.1</asm.version>
+
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.testSource>1.8</maven.compiler.testSource>
+    <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -246,8 +246,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <asm.version>8.0.1</asm.version>
 
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <asm.version>7.3.1</asm.version>
+    <asm.version>8.0.1</asm.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This PR fixes #105 and #92.

There were maven build complaints during build which have been addressed.

While project itself will support jdk 15, the integration tests will not as seen per Travis CI.  This has to do with a wait on groovy to support jdk 15.  They merged the support today to their master but no specific ETA on when they will make that available.  At time I checked they had not yet merged that into the 3.0.0 line that is going through RC status.

In order to support higher jdks with this build, the tests to check for violation of sun.* usage has been removed.  The classes no longer exist in newer jdks and that is a bit of duplication over other checks.  The checks still are valid just test for them are not on higher jdks.  A different solution would need to occur to check for them.  One possibility is to isolate and run in the toolchains.  However, this effort was just to show this was possible to raise the build up.

I do not anticipate this comes in all together.  This was just a POC to show all of this.  Please take a look and indicate how you would like to proceed.  I can raise separate PRs as would be needed.