### PR TITLE
Modify verify.groovy IT test to support cross platform

### DIFF
--- a/modernizer-maven-plugin/src/it/issue-28-option-disabled/verify.groovy
+++ b/modernizer-maven-plugin/src/it/issue-28-option-disabled/verify.groovy
@@ -15,4 +15,5 @@
  */
 
 log = new File(basedir, 'build.log')
-assert log.text.contains('/src/main/java/org/gaul/it/TestClass.java:25: Prefer java.util.ArrayList')
+assert log.text.contains(File.separator + 'src' + File.separator + 'main' + File.separator + 'java' + File.separator + 'org' + File.separator + 'gaul' + File.separator + 'it' + File.separator + 'TestClass.java:25: Prefer java.util.ArrayList')
+


### PR DESCRIPTION
test assuming using *nix.  Fixed so this works on both windows and *nix.

File.separator is required for cross platform support.  When using windows, the default is \ which will fail this IT test.  This IT tests is expecting *nix only.  The result here is the same but ensures cross platform usage uses the right file seperator.