### PR TITLE
[pom] Upgrade invoker plugin to latest and override groovy to latest

### DIFF
--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -20,6 +20,10 @@
     <maven>3.0.5</maven>
   </prerequisites>
 
+  <properties>
+    <groovy.version>3.0.0-rc-3</groovy.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -119,7 +123,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.1</version>
         <configuration>
           <mavenOpts>${argLine}</mavenOpts>
           <debug>true</debug>
@@ -135,6 +139,14 @@
             <goal>test-compile</goal>
           </goals>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>${groovy.version}</version>
+            <type>pom</type>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>integration-test</id>

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
   </prerequisites>
 
   <properties>
-    <groovy.version>3.0.0-rc-3</groovy.version>
+    <groovy.version>3.0.2</groovy.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
To support higher jdks

Maven invoker plugin is on groovy 2.2.2 for jdk 6 and 2.4.8 for jdk 7.  It works without question on latest releases.  In order to support higher jdks, this needs to be overridden otherwise builds will fail.  This does not impact the code base and all IT tests run as with before.