### PR TITLE
[pom] Add missing version to maven jar plugin at 3.2.0

### DIFF
--- a/modernizer-maven-annotations/pom.xml
+++ b/modernizer-maven-annotations/pom.xml
@@ -45,6 +45,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
         <configuration>
           <archive>
             <manifestEntries combine.children="append">


### PR DESCRIPTION
Jar plugin version was not defined in parent about this usage.  While mavens super parent pom will address many of the plugins, they are ultimately going to remove that and enforce proper usage.  Also, higher jdk usage will through warnings due to not defining the version.