### PR TITLE
Allow SuppressModernizer on constructors

### DIFF
--- a/modernizer-maven-annotations/src/main/java/org/gaul/modernizer_maven_annotations/SuppressModernizer.java
+++ b/modernizer-maven-annotations/src/main/java/org/gaul/modernizer_maven_annotations/SuppressModernizer.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
 @Target({
     ElementType.TYPE,
     ElementType.METHOD,
+    ElementType.CONSTRUCTOR,
 })
 public @interface SuppressModernizer {
 }

--- a/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/SuppressModernizerTestClasses.java
+++ b/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/SuppressModernizerTestClasses.java
@@ -39,6 +39,11 @@ public class SuppressModernizerTestClasses {
 
     public static final class SuppressedOnMembers {
         @SuppressModernizer
+        SuppressedOnMembers() {
+            System.out.println(Charsets.UTF_8);
+        }
+
+        @SuppressModernizer
         public Charset getCharset() {
             return Charsets.UTF_8;
         }


### PR DESCRIPTION
I checked if we could allow it on fields as well, but that doesn't seem to get picked up by the current setup.

Fixes https://github.com/gaul/modernizer-maven-plugin/issues/125

@gaul 