### PR TITLE
add violations for primitive wrappers, Base64 and StringUtils.join

### DIFF
--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -26,6 +26,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>30.1.1-jre</version>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -5,7 +5,6 @@
 This file contains the standard set of violations for Modernizer.  The
 violation names use the same format that javap emits.
 -->
-
   <violation>
     <name>com/google/common/base/Function</name>
     <version>1.8</version>
@@ -1355,5 +1354,65 @@ violation names use the same format that javap emits.
     <version>1.11</version>
     <comment>Prefer java.io.FileWriter.&lt;init&gt;(String, Charset, boolean)</comment>
   </violation>
+
+    <violation>
+      <name>org/apache/commons/lang3/StringUtils.join:(Ljava/lang/Iterable;C)Ljava/lang/String;</name>
+      <version>1.8</version>
+      <comment>Prefer java.lang.String.join or use java.util.stream.Stream with java.util.stream.Collectors.joining</comment>
+    </violation>
+
+    <violation>
+        <name>org/apache/commons/lang3/StringUtils.join:(Ljava/lang/Iterable;Ljava/lang/String;)Ljava/lang/String;</name>
+        <version>1.8</version>
+        <comment>Prefer java.lang.String.join or use java.util.stream.Stream with java.util.stream.Collectors.joining</comment>
+    </violation>
+
+    <violation>
+      <name>java/lang/Byte."&lt;init&gt;":(Ljava/lang/String;)V</name>
+      <version>1.9</version>
+      <comment>Prefer java.lang.Byte.valueOf(String) or java.lang.Byte.parseByte(String)</comment>
+    </violation>
+
+    <violation>
+      <name>java/lang/Double."&lt;init&gt;":(Ljava/lang/String;)V</name>
+      <version>1.9</version>
+      <comment>Prefer java.lang.Double.valueOf(String) or java.lang.Double.parseDouble(String)</comment>
+    </violation>
+
+    <violation>
+      <name>java/lang/Float."&lt;init&gt;":(Ljava/lang/String;)V</name>
+      <version>1.9</version>
+      <comment>Prefer java.lang.Float.valueOf(String) or java.lang.Float.parseFloat(String)</comment>
+    </violation>
+
+    <violation>
+      <name>java/lang/Integer."&lt;init&gt;":(Ljava/lang/String;)V</name>
+      <version>1.9</version>
+      <comment>Prefer java.lang.Integer.valueOf(String) or java.lang.Integer.parseInt(String)</comment>
+    </violation>
+
+    <violation>
+      <name>java/lang/Long."&lt;init&gt;":(Ljava/lang/String;)V</name>
+      <version>1.9</version>
+      <comment>Prefer java.lang.Long.valueOf(String) or java.lang.Long.parseLong(String)</comment>
+    </violation>
+
+    <violation>
+      <name>java/lang/Short."&lt;init&gt;":(Ljava/lang/String;)V</name>
+      <version>1.9</version>
+      <comment>Prefer java.lang.Short.valueOf(String) or java.lang.Short.parseShort(String)</comment>
+    </violation>
+
+    <violation>
+        <name>org/apache/commons/codec/binary/Base64.encodeBase64:([B)[B</name>
+        <version>1.8</version>
+        <comment>Prefer java.util.Base64.Encoder</comment>
+    </violation>
+
+    <violation>
+        <name>org/apache/commons/codec/binary/Base64.decodeBase64:([B)[B</name>
+        <version>1.8</version>
+        <comment>Prefer java.util.Base64.Decoder</comment>
+    </violation>
 
 </modernizer>

--- a/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -90,6 +90,7 @@ import com.google.inject.Provider;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.gaul.modernizer_maven_plugin
     .SuppressModernizerTestClasses.SuppressedOnClass;
 import org.gaul.modernizer_maven_plugin
@@ -389,6 +390,8 @@ public final class ModernizerTest {
                 new ClassReader(AllViolations.class.getName()));
         occurrences.addAll(modernizer.check(
                 new ClassReader(Java8Violations.class.getName())));
+        occurrences.addAll(modernizer.check(
+            new ClassReader(Java9Violations.class.getName())));
         occurrences.addAll(modernizer.check(
                 new ClassReader(Java10Violations.class.getName())));
         occurrences.addAll(modernizer.check(
@@ -690,8 +693,6 @@ public final class ModernizerTest {
             new Vector<Object>(1);
             new Vector<Object>(0, 0);
             new Vector<Object>((Collection<Object>) null);
-            Base64.decodeBase64("");
-            Base64.encodeBase64String((byte[]) null);
             object = org.apache.commons.io.Charsets.ISO_8859_1;
             object = org.apache.commons.io.Charsets.US_ASCII;
             object = org.apache.commons.io.Charsets.UTF_8;
@@ -768,6 +769,23 @@ public final class ModernizerTest {
             Iterables.skip(null, 0);
             Iterables.limit(null, 0);
             Iterables.isEmpty(null);
+            StringUtils.join((Iterable<String>) null, ',');
+            StringUtils.join((Iterable<String>) null, null);
+            Base64.decodeBase64("");
+            Base64.decodeBase64((byte[]) null);
+            Base64.encodeBase64String((byte[]) null);
+            Base64.encodeBase64((byte[]) null);
+        }
+    }
+
+    private static class Java9Violations {
+        private static void method() throws Exception {
+            new Byte((String) null);
+            new Double((String) null);
+            new Short((String) null);
+            new Float((String) null);
+            new Integer((String) null);
+            new Long((String) null);
         }
     }
 


### PR DESCRIPTION
As in title.
I added violations for more constructors of primitive wrappers (`new Integer("123")` is deprecated just like `new Integer(123)`).

For StringUtils.join, which can be replaced with String.join or Collectors.joining.

And added more cases for Base64 (encoding from byte[], decoding from byte[]).