### PR TITLE
Fix p-u and update plugin

### DIFF
--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -17,12 +17,11 @@
   <description>Detect use of legacy APIs which modern Java versions supersede.</description>
 
   <prerequisites>
-    <maven>3.2.5</maven>
+    <maven>${mavenVersion}</maven>
   </prerequisites>
 
   <properties>
-    <groovy.version>3.0.2</groovy.version>
-    <maven.version>3.2.5</maven.version>
+    <mavenVersion>3.2.5</mavenVersion>
   </properties>
 
   <dependencies>
@@ -65,7 +64,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -157,7 +156,7 @@
           <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
+            <version>3.0.2</version>
             <type>pom</type>
           </dependency>
         </dependencies>

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -17,11 +17,12 @@
   <description>Detect use of legacy APIs which modern Java versions supersede.</description>
 
   <prerequisites>
-    <maven>3.0.5</maven>
+    <maven>3.2.5</maven>
   </prerequisites>
 
   <properties>
     <groovy.version>3.0.2</groovy.version>
+    <maven.version>3.2.5</maven.version>
   </properties>
 
   <dependencies>
@@ -70,24 +71,20 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.2</version>
+      <version>3.6.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>2.2.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-utils</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -113,6 +110,11 @@
       <groupId>org.gaul</groupId>
       <artifactId>modernizer-maven-annotations</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.5.0</version>
     </dependency>
   </dependencies>
 

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>${maven.version}</version>
+      <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>${maven.version}</version>
+      <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Changes:
* add direct dependency onto p-u (was auto-inject in Maven 2 but will not be anymore)
* update prerequisite to Maven 3.2.5 (3.0.x was 10+ years ago and is really dead-dead)
* drop Maven 2 artifact dependencies, switch to required version artifacts instead
* move Maven bits to "provided" scope (as they ARE provided at runtime)

Fixes #152 