### PR TITLE
Remove usage of plexus StringUtils

### DIFF
--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
@@ -42,7 +42,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.StringUtils;
 import org.xml.sax.SAXException;
 
 @Mojo(name = "modernizer", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES,
@@ -190,7 +189,7 @@ public final class ModernizerMojo extends AbstractMojo {
             return;
         }
 
-        if (StringUtils.isEmpty(javaVersion)) {
+        if (javaVersion == null || javaVersion.isEmpty()) {
             throw new MojoExecutionException(
                     "javaVersion is not set but is required for execution.");
         }


### PR DESCRIPTION
When using this plugin with maven-3.9.0, `ClassNotFoundException` and `NoClassDefFoundError` are being thrown because it appears like `org.codehaus.plexus.util.StringUtils` is no longer provided by maven.

The only usage of that class was checking a string for empty, refactored that usage to do the empty checks directly.

```
Caused by: java.lang.NoClassDefFoundError: org/codehaus/plexus/util/StringUtils
    at org.gaul.modernizer_maven_plugin.ModernizerMojo.execute (ModernizerMojo.java:193)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:342)
```

```
Caused by: java.lang.ClassNotFoundException: org.codehaus.plexus.util.StringUtils
    at org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy.loadClass (SelfFirstStrategy.java:50)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.unsynchronizedLoadClass (ClassRealm.java:271)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:247)
    at org.codehaus.plexus.classworlds.realm.ClassRealm.loadClass (ClassRealm.java:239)
    at org.gaul.modernizer_maven_plugin.ModernizerMojo.execute (ModernizerMojo.java:193)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
```
