### PR TITLE
Require Java 8 for compilation and execution

### DIFF
--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -654,18 +654,6 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
-    <name>sun/misc/BASE64Decoder.decodeBuffer:(Ljava/lang/String;)[B</name>
-    <version>8</version>
-    <comment>Prefer java.util.Base64.Decoder.decode(String)</comment>
-  </violation>
-
-  <violation>
-    <name>sun/misc/BASE64Encoder.encode:([B)Ljava/lang/String;</name>
-    <version>8</version>
-    <comment>Prefer java.util.Base64.Encoder.encodeToString(byte[])</comment>
-  </violation>
-
-  <violation>
     <name>com/google/common/base/Preconditions.checkNotNull:(Ljava/lang/Object;)Ljava/lang/Object;</name>
     <version>7</version>
     <comment>Prefer java.util.Objects.requireNonNull(Object)</comment>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -654,6 +654,18 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>sun/misc/BASE64Decoder.decodeBuffer:(Ljava/lang/String;)[B</name>
+    <version>8</version>
+    <comment>Prefer java.util.Base64.Decoder.decode(String)</comment>
+  </violation>
+
+  <violation>
+    <name>sun/misc/BASE64Encoder.encode:([B)Ljava/lang/String;</name>
+    <version>8</version>
+    <comment>Prefer java.util.Base64.Encoder.encodeToString(byte[])</comment>
+  </violation>
+
+  <violation>
     <name>com/google/common/base/Preconditions.checkNotNull:(Ljava/lang/Object;)Ljava/lang/Object;</name>
     <version>7</version>
     <comment>Prefer java.util.Objects.requireNonNull(Object)</comment>

--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <compilerArguments>


### PR DESCRIPTION
This bumps the source level and target to Java 8. As a side-effect, the checks for sun.misc.BASE64* are removed, as we can no longer test them.