### PR TITLE
Add Enumeration to legacy apis

### DIFF
--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -534,6 +534,12 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>java/util/Enumeration</name>
+    <version>2</version>
+    <comment>Prefer java.util.Iterator</comment>
+  </violation>
+
+  <violation>
     <name>java/util/Hashtable."&lt;init&gt;":(IF)V</name>
     <version>2</version>
     <comment>Prefer java.util.HashMap</comment>

--- a/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Enumeration;
 import java.util.Formatter;
 import java.util.Hashtable;
 import java.util.Locale;
@@ -419,6 +420,8 @@ public final class ModernizerTest {
             new ClassReader(Java19Violations.class.getName())));
         // must visit inner classes manually
         occurrences.addAll(modernizer.check(
+                new ClassReader(EnumerationTestClass.class.getName())));
+        occurrences.addAll(modernizer.check(
                 new ClassReader(VoidFunction.class.getName())));
         occurrences.addAll(modernizer.check(
                 new ClassReader(VoidPredicate.class.getName())));
@@ -514,6 +517,14 @@ public final class ModernizerTest {
 
     private static class StringGetBytesCharset {
         private final Object object = "".getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static class EnumerationTestClass implements Enumeration<Object> {
+        @Override
+        public boolean hasMoreElements() { return false; }
+
+        @Override
+        public Object nextElement() { return null; }
     }
 
     private static class VoidFunction implements Function<Void, Void> {


### PR DESCRIPTION
This doesn't ban all uses of Enumeration though. It only catches code like

``` java
class TpEnumeration implements Enumeration<Object> {
```

Any ideas?