### PR TITLE
Issues 184 sortpom

### DIFF
--- a/modernizer-maven-annotations/pom.xml
+++ b/modernizer-maven-annotations/pom.xml
@@ -1,17 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.gaul</groupId>
     <artifactId>modernizer-maven-parent</artifactId>
     <version>2.7.0-SNAPSHOT</version>
   </parent>
-
   <artifactId>modernizer-maven-annotations</artifactId>
   <name>Modernizer Maven Plugin annotations</name>
-
   <build>
     <plugins>
+      <plugin>
+        <groupId>codes.rafael.modulemaker</groupId>
+        <artifactId>modulemaker-maven-plugin</artifactId>
+        <version>1.9</version>
+        <configuration>
+          <name>org.gaul.modernizer_maven_annotations</name>
+          <exports>org.gaul.modernizer_maven_annotations</exports>
+          <multirelease>true</multirelease>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>inject-module</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
@@ -25,24 +41,6 @@
             <version>${project.version}</version>
           </dependency>
         </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>codes.rafael.modulemaker</groupId>
-        <artifactId>modulemaker-maven-plugin</artifactId>
-        <version>1.9</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>inject-module</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <name>org.gaul.modernizer_maven_annotations</name>
-          <exports>org.gaul.modernizer_maven_annotations</exports>
-          <multirelease>true</multirelease>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -1,36 +1,23 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.gaul</groupId>
     <artifactId>modernizer-maven-parent</artifactId>
     <version>2.7.0-SNAPSHOT</version>
   </parent>
-
   <artifactId>modernizer-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-
   <name>Modernizer Maven Plugin</name>
-  <url>https://github.com/gaul/modernizer-maven-plugin</url>
   <description>Detect use of legacy APIs which modern Java versions supersede.</description>
-
+  <url>https://github.com/gaul/modernizer-maven-plugin</url>
   <prerequisites>
     <maven>${mavenVersion}</maven>
   </prerequisites>
-
   <properties>
     <mavenVersion>3.2.5</mavenVersion>
   </properties>
-
   <dependencies>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -68,6 +55,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${mavenVersion}</version>
@@ -80,16 +79,20 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>1.7.1</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.gaul</groupId>
+      <artifactId>modernizer-maven-annotations</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
@@ -105,18 +108,7 @@
       <version>5.3.18</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.gaul</groupId>
-      <artifactId>modernizer-maven-annotations</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>3.5.0</version>
-    </dependency>
   </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/modernizer-maven-policy/pom.xml
+++ b/modernizer-maven-policy/pom.xml
@@ -1,12 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.gaul</groupId>
     <artifactId>modernizer-maven-parent</artifactId>
     <version>2.7.0-SNAPSHOT</version>
   </parent>
-
   <artifactId>modernizer-maven-policy</artifactId>
   <name>Modernizer Maven Plugin policy</name>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>7</version>
-    <relativePath />
+    <relativePath/>
   </parent>
-
   <groupId>org.gaul</groupId>
   <artifactId>modernizer-maven-parent</artifactId>
   <version>2.7.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-
   <name>Modernizer Maven Plugin parent</name>
+  <organization>
+    <name>Gaul</name>
+    <url>https://github.com/gaul/</url>
+  </organization>
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -21,37 +23,27 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-
-  <organization>
-    <name>Gaul</name>
-    <url>https://github.com/gaul/</url>
-  </organization>
-
-  <scm>
-    <connection>scm:git:git@github.com:gaul/modernizer-maven-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:gaul/modernizer-maven-plugin.git</developerConnection>
-    <url>git@github.com:gaul/modernizer-maven-plugin.git</url>
-  </scm>
-
-  <issueManagement>
-    <system>Github</system>
-    <url>https://github.com/gaul/modernizer-maven-plugin/issues</url>
-  </issueManagement>
-
   <developers>
     <developer>
-      <name>Andrew Gaul</name>
       <id>gaul</id>
+      <name>Andrew Gaul</name>
       <email>andrew@gaul.org</email>
     </developer>
   </developers>
-
   <modules>
     <module>modernizer-maven-annotations</module>
     <module>modernizer-maven-plugin</module>
     <module>modernizer-maven-policy</module>
   </modules>
-
+  <scm>
+    <connection>scm:git:git@github.com:gaul/modernizer-maven-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:gaul/modernizer-maven-plugin.git</developerConnection>
+    <url>git@github.com:gaul/modernizer-maven-plugin.git</url>
+  </scm>
+  <issueManagement>
+    <system>Github</system>
+    <url>https://github.com/gaul/modernizer-maven-plugin/issues</url>
+  </issueManagement>
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
@@ -63,73 +55,40 @@
       <url>scm:git:ssh://git@github.com/gaul/modernizer-maven-plugin.git</url>
     </site>
   </distributionManagement>
-
-  <profiles>
-    <profile>
-      <id>release</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
-            <executions>
-              <execution>
-                <id>sign-artifacts</id>
-                <phase>verify</phase>
-                <goals>
-                  <goal>sign</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-    <id>m2e-only</id>
-    <activation>
-      <property>
-        <!-- this property is set in Eclipse only, thus activating the profile automatically
-        and not annoying people that don't use Eclipse with the fake plugin -->
-        <name>m2e.version</name>
-      </property>
-    </activation>
-    <build>
-      <pluginManagement>
-        <plugins>
-          <plugin>
-            <groupId>org.eclipse.m2e</groupId>
-            <artifactId>lifecycle-mapping</artifactId>
-            <version>1.0.0</version>
-            <configuration>
-              <lifecycleMappingMetadata>
-                <pluginExecutions>
-                  <pluginExecution>
-                    <pluginExecutionFilter>
-                      <groupId>org.apache.maven.plugins</groupId>
-                      <artifactId>maven-plugin-plugin</artifactId>
-                      <versionRange>[0,)</versionRange>
-                      <goals>
-                        <goal>descriptor</goal>
-                        <goal>helpmojo</goal>
-                      </goals>
-                    </pluginExecutionFilter>
-                    <action>
-                      <ignore />
-                    </action>
-                  </pluginExecution>
-                </pluginExecutions>
-              </lifecycleMappingMetadata>
-            </configuration>
-          </plugin>
-        </plugins>
-      </pluginManagement>
-    </build>
-    </profile>
-  </profiles>
-
+  <properties>
+    <asm.version>9.4</asm.version>
+    <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
+    <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>${asm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-commons</artifactId>
+        <version>${asm.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.9.1</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>com.github.ekryd.sortpom</groupId>
@@ -157,18 +116,17 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.6.0.0</version>
+        <configuration>
+          <effort>Max</effort>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>
-        <executions>
-          <execution>
-            <id>checkstyle</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <!--
           TODO: cannot ignore generated files
@@ -180,6 +138,15 @@
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
           <violationSeverity>warning</violationSeverity>
         </configuration>
+        <executions>
+          <execution>
+            <id>checkstyle</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -191,7 +158,7 @@
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <compilerArguments>
-            <Xlint />
+            <Xlint/>
           </compilerArguments>
         </configuration>
       </plugin>
@@ -233,6 +200,37 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-scm-publish-plugin</artifactId>
+        <version>3.2.1</version>
+        <configuration>
+          <scmBranch>gh-pages</scmBranch>
+          <tryUpdate>true</tryUpdate>
+          <addUniqueDirectory>true</addUniqueDirectory>
+          <content>${java.io.tmpdir}/staging</content>
+        </configuration>
+        <executions>
+          <execution>
+            <id>scm-publish</id>
+            <goals>
+              <goal>publish-scm</goal>
+            </goals>
+            <phase>site-deploy</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skipDeploy>true</skipDeploy>
+          <generateSitemap>true</generateSitemap>
+          <attach>false</attach>
+          <locales>en</locales>
+          <outputEncoding>${project.build.sourceEncoding}</outputEncoding>
+          <relativizeDecorationLinks>false</relativizeDecorationLinks>
+          <stagingDirectory>${java.io.tmpdir}/staging</stagingDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>3.2.1</version>
@@ -258,30 +256,22 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.6.0.0</version>
-        <configuration>
-          <effort>Max</effort>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.gaul</groupId>
         <artifactId>modernizer-maven-plugin</artifactId>
         <version>1.9.0</version>
-        <executions>
-          <execution>
-            <id>modernizer</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>modernizer</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <javaVersion>1.6</javaVersion>
           <includeTestClasses>false</includeTestClasses>
         </configuration>
+        <executions>
+          <execution>
+            <id>modernizer</id>
+            <goals>
+              <goal>modernizer</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
@@ -294,53 +284,8 @@
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
-      <plugin>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skipDeploy>true</skipDeploy>
-          <generateSitemap>true</generateSitemap>
-          <attach>false</attach>
-          <locales>en</locales>
-          <outputEncoding>${project.build.sourceEncoding}</outputEncoding>
-          <relativizeDecorationLinks>false</relativizeDecorationLinks>
-          <stagingDirectory>${java.io.tmpdir}/staging</stagingDirectory>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-scm-publish-plugin</artifactId>
-        <version>3.2.1</version>
-        <configuration>
-          <scmBranch>gh-pages</scmBranch>
-          <tryUpdate>true</tryUpdate>
-          <addUniqueDirectory>true</addUniqueDirectory>
-          <content>${java.io.tmpdir}/staging</content>
-        </configuration>
-        <executions>
-          <execution>
-            <id>scm-publish</id>
-            <phase>site-deploy</phase>
-            <goals>
-              <goal>publish-scm</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.9.1</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
-
   <reporting>
     <plugins>
       <plugin>
@@ -350,6 +295,9 @@
       <plugin>
         <artifactId>maven-project-info-reports-plugin</artifactId>
         <version>${maven-project-info-reports-plugin.version}</version>
+        <configuration>
+          <dependencyDetailsEnabled>true</dependencyDetailsEnabled>
+        </configuration>
         <reportSets>
           <reportSet>
             <reports>
@@ -371,32 +319,71 @@
             </reports>
           </reportSet>
         </reportSets>
-        <configuration>
-          <dependencyDetailsEnabled>true</dependencyDetailsEnabled>
-        </configuration>
       </plugin>
     </plugins>
   </reporting>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <asm.version>9.4</asm.version>
-    <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
-    <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
-  </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm</artifactId>
-        <version>${asm.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm-commons</artifactId>
-        <version>${asm.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <phase>verify</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>m2e-only</id>
+      <activation>
+        <property>
+          <!-- this property is set in Eclipse only, thus activating the profile automatically
+        and not annoying people that don't use Eclipse with the fake plugin -->
+          <name>m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.eclipse.m2e</groupId>
+              <artifactId>lifecycle-mapping</artifactId>
+              <version>1.0.0</version>
+              <configuration>
+                <lifecycleMappingMetadata>
+                  <pluginExecutions>
+                    <pluginExecution>
+                      <pluginExecutionFilter>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-plugin-plugin</artifactId>
+                        <versionRange>[0,)</versionRange>
+                        <goals>
+                          <goal>descriptor</goal>
+                          <goal>helpmojo</goal>
+                        </goals>
+                      </pluginExecutionFilter>
+                      <action>
+                        <ignore/>
+                      </action>
+                    </pluginExecution>
+                  </pluginExecutions>
+                </lifecycleMappingMetadata>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,31 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>com.github.ekryd.sortpom</groupId>
+        <artifactId>sortpom-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <configuration>
+          <lineSeparator>\n</lineSeparator>
+          <encoding>${project.build.sourceEncoding}</encoding>
+          <sortExecutions>false</sortExecutions>
+          <sortProperties>true</sortProperties>
+          <sortModules>false</sortModules>
+          <sortPlugins>groupId,artifactId</sortPlugins>
+          <sortDependencies>groupId,artifactId</sortDependencies>
+          <keepBlankLines>false</keepBlankLines>
+          <expandEmptyElements>false</expandEmptyElements>
+          <spaceBeforeCloseEmptyElement>false</spaceBeforeCloseEmptyElement>
+          <createBackupFile>false</createBackupFile>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>sort</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>
@@ -180,6 +205,7 @@
             <goals>
               <goal>jar</goal>
             </goals>
+            <phase>prepare-package</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
This sortpom-maven-plugin was added to the build.

When the sort happens in the second commit it reorders the javadoc/modulemaker execution order in the annotations module, so I have to pull the javadoc execution back a phase.