### PR TITLE
Add support for different output formats and add codeclimate as an output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ documents all of these.  The most commonly used flags:
 * `-Dmodernizer.failOnViolations` - fail phase if violations detected, defaults to true
 * `-Dmodernizer.skip` - skip plugin execution, defaults to false
 
+### Output Formats
+
+The plugin can output Modernizer violations in one of many formats which can be configured with the `<configuration>`
+stanza using `<outputFormat>`.
+
+The currently supported formats and their respective configuration options are outlined below:
+* `CONSOLE` List each violation using Maven's logger. This is the **default** format.
+  * `<violationLogLevel>` Specify the log level of the logger: `error`, `warn`, `info` or `debug`.
+Default is `error`.
+* `CODE_CLIMATE` Write the violations according to [Code Climate's Spec](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md). 
+GitLab uses this format for its code quality as shown [here](https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool).
+  * `<outputFile>` The full path the file to output to. Default is `${project.build.directory}/code-quality.json`
+  * `<codeClimateSeverity>` Severity of Modernizer violations for CodeClimate: `INFO`, `MINOR`, `MAJOR`, `CRITIAL` or `BLOCKER`.
+Default is `MINOR`.
+
 Ignoring elements
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Default is `error`.
 * `CODE_CLIMATE` Write the violations according to [Code Climate's Spec](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md). 
 GitLab uses this format for its code quality as shown [here](https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool).
   * `<outputFile>` The full path the file to output to. Default is `${project.build.directory}/code-quality.json`
-  * `<codeClimateSeverity>` Severity of Modernizer violations for CodeClimate: `INFO`, `MINOR`, `MAJOR`, `CRITIAL` or `BLOCKER`.
+  * `<codeClimateSeverity>` Severity of Modernizer violations for CodeClimate: `INFO`, `MINOR`, `MAJOR`, `CRITICAL` or `BLOCKER`.
 Default is `MINOR`.
 
 Ignoring elements

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -115,6 +115,11 @@
       <artifactId>plexus-utils</artifactId>
       <version>4.0.0</version>
     </dependency>
+      <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.10.1</version>
+      </dependency>
   </dependencies>
 
   <build>

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/CodeClimateOutputer.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/CodeClimateOutputer.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2014-2022 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.modernizer_maven_plugin.output;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+
+import org.gaul.modernizer_maven_plugin.Violation;
+
+public final class CodeClimateOutputer implements Outputer {
+    public static final String DEFAULT_FILENAME = "code-quality.json";
+
+    private final String outputFile;
+    private final Severity severity;
+
+    public CodeClimateOutputer(String outputFile, Severity severity) {
+        this.outputFile = outputFile;
+        this.severity = severity;
+    }
+
+    @Override
+    public void output(List<OutputEntry> entries) throws IOException {
+        List<Entry> toOutput = new ArrayList<>(entries.size());
+        for (OutputEntry entry : entries) {
+            Location location = new Location(
+                    entry.getFileName(),
+                    new Location.Lines(entry.getOccurrence().getLineNumber()));
+            Violation violation = entry.getOccurrence().getViolation();
+            toOutput.add(new Entry(
+                    violation.getComment(),
+                    violation.getName(),
+                    Integer.toString(entry.hashCode()),
+                    severity,
+                    location));
+        }
+        TypeToken<List<Entry>> type = new TypeToken<List<Entry>>() {
+        };
+        OutputStreamWriter writer = new OutputStreamWriter(
+                Files.newOutputStream(Paths.get(outputFile)),
+                StandardCharsets.UTF_8);
+        new Gson().toJson(toOutput, type.getType(), writer);
+        writer.close();
+    }
+
+    public enum Severity {
+        @SerializedName("info")
+        INFO,
+
+        @SerializedName("minor")
+        MINOR,
+
+        @SerializedName("major")
+        MAJOR,
+
+        @SerializedName("critical")
+        CRITICAL,
+
+        @SerializedName("blocker")
+        BLOCKER;
+    }
+
+    private static final class Entry {
+        private final String description;
+        private final String checkName;
+        private final String fingerprint;
+        private final Severity severity;
+        private final Location location;
+
+        private Entry(String description,
+                      String checkName,
+                      String fingerprint,
+                      Severity severity,
+                      Location location) {
+            this.description = description;
+            this.checkName = checkName;
+            this.fingerprint = fingerprint;
+            this.severity = severity;
+            this.location = location;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getCheckName() {
+            return checkName;
+        }
+
+        public String getFingerprint() {
+            return fingerprint;
+        }
+
+        public Severity getSeverity() {
+            return severity;
+        }
+
+        public Location getLocation() {
+            return location;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Entry)) {
+                return false;
+            }
+            Entry that = (Entry) o;
+            return Objects.equals(description, that.description) &&
+                    Objects.equals(checkName, that.checkName) &&
+                    Objects.equals(fingerprint, that.fingerprint) &&
+                    severity == that.severity &&
+                    Objects.equals(location, that.location);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(description,
+                    checkName,
+                    fingerprint,
+                    severity,
+                    location);
+        }
+
+        @Override
+        public String toString() {
+            return "CodeClimateEntry{" +
+                    "description='" + description + '\'' +
+                    ", checkName='" + checkName + '\'' +
+                    ", fingerprint='" + fingerprint + '\'' +
+                    ", severity=" + severity +
+                    ", location=" + location +
+                    '}';
+        }
+    }
+
+    private static final class Location {
+        private final String path;
+        private final Lines lines;
+
+        private Location(String path, Lines lines) {
+            this.path = path;
+            this.lines = lines;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public Lines getLines() {
+            return lines;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Location)) {
+                return false;
+            }
+            Location location = (Location) o;
+            return Objects.equals(path, location.path) &&
+                    Objects.equals(lines, location.lines);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(path, lines);
+        }
+
+        @Override
+        public String toString() {
+            return "Location{" +
+                    "path='" + path + '\'' +
+                    ", lines=" + lines +
+                    '}';
+        }
+
+        private static final class Lines {
+            private final int begin;
+
+            private Lines(int begin) {
+                this.begin = begin;
+            }
+
+            public int getBegin() {
+                return begin;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (!(o instanceof Lines)) {
+                    return false;
+                }
+                Lines lines = (Lines) o;
+                return begin == lines.begin;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(begin);
+            }
+
+            @Override
+            public String toString() {
+                return "Lines{" +
+                        "begin=" + begin +
+                        '}';
+            }
+        }
+    }
+
+}

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/CodeClimateOutputer.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/CodeClimateOutputer.java
@@ -59,11 +59,11 @@ public final class CodeClimateOutputer implements Outputer {
         }
         TypeToken<List<Entry>> type = new TypeToken<List<Entry>>() {
         };
-        OutputStreamWriter writer = new OutputStreamWriter(
+        try (OutputStreamWriter writer = new OutputStreamWriter(
                 Files.newOutputStream(Paths.get(outputFile)),
-                StandardCharsets.UTF_8);
-        new Gson().toJson(toOutput, type.getType(), writer);
-        writer.close();
+                StandardCharsets.UTF_8)) {
+            new Gson().toJson(toOutput, type.getType(), writer);
+        }
     }
 
     public enum Severity {

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/LoggerOutputer.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/LoggerOutputer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014-2022 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.modernizer_maven_plugin.output;
+
+import java.util.List;
+
+import org.apache.maven.plugin.logging.Log;
+
+public final class LoggerOutputer implements Outputer {
+    private final Log log;
+    private final String level;
+
+    public LoggerOutputer(Log log, String level) {
+        this.log = log;
+        this.level = level;
+    }
+
+    @Override
+    public void output(List<OutputEntry> entries) {
+        for (OutputEntry entry : entries) {
+            String message = entry.getFileName() + ":" +
+                    entry.getOccurrence().getLineNumber() + ": " +
+                    entry.getOccurrence().getViolation().getComment();
+            if (level.equals("error")) {
+                log.error(message);
+            } else if (level.equals("warn")) {
+                log.warn(message);
+            } else if (level.equals("info")) {
+                log.info(message);
+            } else if (level.equals("debug")) {
+                log.debug(message);
+            } else {
+                throw new IllegalStateException(
+                        "unexpected log level, was: " + level);
+            }
+        }
+    }
+}

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/OutputEntry.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/OutputEntry.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2022 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.modernizer_maven_plugin.output;
+
+import java.util.Objects;
+
+import org.gaul.modernizer_maven_plugin.ViolationOccurrence;
+
+public final class OutputEntry {
+    private final String fileName;
+    private final ViolationOccurrence occurrence;
+
+    public OutputEntry(String fileName, ViolationOccurrence occurrence) {
+        this.fileName = fileName;
+        this.occurrence = occurrence;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public ViolationOccurrence getOccurrence() {
+        return occurrence;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof OutputEntry)) {
+            return false;
+        }
+        OutputEntry that = (OutputEntry) o;
+        return Objects.equals(fileName, that.fileName) &&
+                Objects.equals(occurrence, that.occurrence);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fileName, occurrence);
+    }
+
+    @Override
+    public String toString() {
+        return "OutputEntry{" +
+                "fileName='" + fileName + '\'' +
+                ", occurrence=" + occurrence +
+                '}';
+    }
+}

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/OutputFormat.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/OutputFormat.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2022 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.modernizer_maven_plugin.output;
+
+public enum OutputFormat {
+    CONSOLE, CODE_CLIMATE
+}

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/Outputer.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/output/Outputer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2022 Andrew Gaul <andrew@gaul.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gaul.modernizer_maven_plugin.output;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface Outputer {
+    void output(List<OutputEntry> entries) throws IOException;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.12.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <compilerArguments>


### PR DESCRIPTION
The `source` and `target` for the parent pom was changed to `1.7` due to:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.12.1:compile (default-compile) on project modernizer-maven-plugin: Compilation failure: Compilation failure: 
[ERROR] Source option 6 is no longer supported. Use 7 or later.
[ERROR] Target option 6 is no longer supported. Use 7 or later.
```