### PR TITLE
Prepare for 3.0.0-SNAPSHOT

### DIFF
--- a/modernizer-maven-annotations/pom.xml
+++ b/modernizer-maven-annotations/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gaul</groupId>
     <artifactId>modernizer-maven-parent</artifactId>
-    <version>2.9.0</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>modernizer-maven-annotations</artifactId>

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.gaul</groupId>
     <artifactId>modernizer-maven-parent</artifactId>
-    <version>2.9.0</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>modernizer-maven-plugin</artifactId>

--- a/modernizer-maven-policy/pom.xml
+++ b/modernizer-maven-policy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gaul</groupId>
     <artifactId>modernizer-maven-parent</artifactId>
-    <version>2.9.0</version>
+    <version>3.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>modernizer-maven-policy</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.gaul</groupId>
   <artifactId>modernizer-maven-parent</artifactId>
-  <version>2.9.0</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Modernizer Maven Plugin parent</name>


### PR DESCRIPTION
Just bump to 3.0.0-SNAPSHOT, as current master when rebuilt/installed will replace "official" plugin in user local repository.