### PR TITLE
Align to Maven 3.6.3, update plugins, tidy up plugin versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ '8' ]
-        maven: [ '3.2.5', '3.6.3', '3.9.6' ]
+        maven: [ '3.6.3', '3.9.6' ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK
@@ -23,6 +23,6 @@ jobs:
         distribution: 'zulu'
         java-version: ${{ matrix.java }}
     - name: Set up Maven
-      run: mvn -e -B -V org.apache.maven.plugins:maven-wrapper-plugin:3.2.0:wrapper "-Dmaven=${{ matrix.maven }}" -Dtype=only-script
+      run: mvn -e -B -V org.apache.maven.plugins:maven-wrapper-plugin:3.3.1:wrapper "-Dmaven=${{ matrix.maven }}" -Dtype=only-script
     - name: Build with Maven
       run: ./mvnw -e -B -V clean verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         java: [ '8' ]
-        maven: [ '3.6.3', '3.9.6' ]
+        maven: [ '3.6.3', '3.8.8', '3.9.6' ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK

--- a/modernizer-maven-annotations/pom.xml
+++ b/modernizer-maven-annotations/pom.xml
@@ -13,6 +13,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
           <configLocation>checkstyle/checkstyle.xml</configLocation>
@@ -29,7 +30,6 @@
       <plugin>
         <groupId>codes.rafael.modulemaker</groupId>
         <artifactId>modulemaker-maven-plugin</artifactId>
-        <version>1.11</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -45,8 +45,8 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
         <configuration>
           <archive>
             <manifestEntries combine.children="append">

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -26,6 +26,59 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${mavenVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.gaul</groupId>
+      <artifactId>modernizer-maven-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.5.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.25.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.14.0</version>
@@ -34,7 +87,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.1.0-jre</version>
+      <version>33.2.0-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -52,7 +105,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.15.1</version>
+      <version>2.16.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -62,64 +115,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-plugin-api</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.plugin-tools</groupId>
-      <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.11.0</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>3.25.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm-commons</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
       <version>5.3.20</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.gaul</groupId>
-      <artifactId>modernizer-maven-annotations</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>4.0.0</version>
-    </dependency>
-      <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.10.1</version>
-      </dependency>
   </dependencies>
 
   <build>

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -17,7 +17,7 @@
   <description>Detect use of legacy APIs which modern Java versions supersede.</description>
 
   <prerequisites>
-    <maven>3.2.5</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <properties>
@@ -125,6 +125,7 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
           <configLocation>checkstyle/checkstyle.xml</configLocation>
@@ -141,7 +142,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.6.1</version>
         <configuration>
           <mavenOpts>${argLine}</mavenOpts>
           <debug>true</debug>
@@ -161,7 +161,7 @@
           <dependency>
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>4.0.20</version>
+            <version>4.0.21</version>
             <type>pom</type>
           </dependency>
         </dependencies>

--- a/modernizer-maven-plugin/pom.xml
+++ b/modernizer-maven-plugin/pom.xml
@@ -34,6 +34,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
+      <version>${maven-plugin-plugin.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -42,6 +43,7 @@
       <version>${mavenVersion}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,16 @@
     <url>git@github.com:gaul/modernizer-maven-plugin.git</url>
   </scm>
 
+  <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <asm.version>9.7</asm.version>
+    <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
+    <maven-plugin-plugin.version>3.13.0</maven-plugin-plugin.version>
+  </properties>
+
   <issueManagement>
     <system>Github</system>
     <url>https://github.com/gaul/modernizer-maven-plugin/issues</url>
@@ -72,7 +82,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.2</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -134,7 +143,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>checkstyle</id>
@@ -159,10 +167,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.12.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
           <proc>none</proc>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
@@ -174,7 +179,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -185,8 +189,8 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>${maven-plugin-plugin.version}</version>
         <configuration>
           <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
@@ -210,7 +214,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -223,7 +226,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.5</version>
         <configuration>
           <parallel>classes</parallel>
           <threadCount>1</threadCount>
@@ -235,7 +237,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.8.3.1</version>
+        <version>4.8.5.0</version>
         <configuration>
           <effort>Max</effort>
         </configuration>
@@ -243,7 +245,7 @@
       <plugin>
         <groupId>org.gaul</groupId>
         <artifactId>modernizer-maven-plugin</artifactId>
-        <version>1.9.0</version>
+        <version>2.9.0</version>
         <executions>
           <execution>
             <id>modernizer</id>
@@ -254,7 +256,7 @@
           </execution>
         </executions>
         <configuration>
-          <javaVersion>1.6</javaVersion>
+          <javaVersion>${maven.compiler.source}</javaVersion>
           <includeTestClasses>false</includeTestClasses>
         </configuration>
       </plugin>
@@ -270,6 +272,7 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <configuration>
           <skipDeploy>true</skipDeploy>
@@ -282,8 +285,8 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
-        <version>3.2.1</version>
         <configuration>
           <scmBranch>gh-pages</scmBranch>
           <tryUpdate>true</tryUpdate>
@@ -303,42 +306,107 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.4.1</version>
-        <executions>
-          <execution>
-            <id>enforce-versions</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>3.2.5</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <version>8</version>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>3.3.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.4.1</version>
+          <executions>
+            <execution>
+              <id>enforce-versions</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>3.6.3</version>
+                  </requireMavenVersion>
+                  <requireJavaVersion>
+                    <version>${maven.compiler.source}</version>
+                  </requireJavaVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>3.2.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>3.6.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.4.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.6.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>${maven-plugin-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>${maven-project-info-reports-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-publish-plugin</artifactId>
+          <version>3.2.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.12.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.5</version>
+        </plugin>
+
+        <plugin>
+          <groupId>codes.rafael.modulemaker</groupId>
+          <artifactId>modulemaker-maven-plugin</artifactId>
+          <version>1.11</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -347,12 +415,12 @@
   <reporting>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>${maven-plugin-plugin.version}</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>${maven-project-info-reports-plugin.version}</version>
         <reportSets>
           <reportSet>
             <reports>
@@ -380,13 +448,6 @@
       </plugin>
     </plugins>
   </reporting>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <asm.version>9.7</asm.version>
-    <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
-    <maven-plugin-plugin.version>3.11.0</maven-plugin-plugin.version>
-  </properties>
 
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,12 @@
         <artifactId>asm-commons</artifactId>
         <version>${asm.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.apache.maven.plugin-tools</groupId>
+        <artifactId>maven-plugin-annotations</artifactId>
+        <version>${maven-plugin-plugin.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
                     <version>3.6.3</version>
                   </requireMavenVersion>
                   <requireJavaVersion>
-                    <version>${maven.compiler.source}</version>
+                    <version>1.${maven.compiler.source}</version>
                   </requireJavaVersion>
                 </rules>
               </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -461,12 +461,6 @@
         <artifactId>asm-commons</artifactId>
         <version>${asm.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>org.apache.maven.plugin-tools</groupId>
-        <artifactId>maven-plugin-annotations</artifactId>
-        <version>${maven-plugin-plugin.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
Concentrate ALL plugin versions in one single place: build/pluginMgmt

Note: plexus-utils was 4.0.0, downgraded it to 3.5.1 to make sure Maven3 compatibility. p-u 4.x is for Maven4 stuff, and while Maven4 is backard compat is fine using p-u 3.5.1, older Maven3 versions may squeak with p-u 4.x. If you target Maven3 compatibility in plugin (and currently you do), better use 3.x line of p-u.