### PR TITLE
Add violation for StringReader

### DIFF
--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -426,6 +426,12 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>java/io/StringReader."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>24</version>
+    <comment>Prefer java.io.Reader.of(java.lang.CharSequence)</comment>
+  </violation>
+
+  <violation>
     <name>java/lang/Byte."&lt;init&gt;":(B)V</name>
     <version>5</version>
     <comment>Prefer java.lang.Byte.valueOf(byte)</comment>

--- a/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.NetworkInterface;
 import java.net.URLDecoder;
@@ -399,7 +400,7 @@ public final class ModernizerTest {
 
     @Test
     public void testAllViolations() throws Exception {
-        Modernizer modernizer = createModernizer("19");
+        Modernizer modernizer = createModernizer("24");
         Collection<ViolationOccurrence> occurrences = modernizer.check(
                 new ClassReader(AllViolations.class.getName()));
         occurrences.addAll(modernizer.check(
@@ -418,6 +419,8 @@ public final class ModernizerTest {
             new ClassReader(Java18Violations.class.getName())));
         occurrences.addAll(modernizer.check(
             new ClassReader(Java19Violations.class.getName())));
+        occurrences.addAll(modernizer.check(
+            new ClassReader(Java24Violations.class.getName())));
         // must visit inner classes manually
         occurrences.addAll(modernizer.check(
                 new ClassReader(EnumerationTestClass.class.getName())));
@@ -844,6 +847,12 @@ public final class ModernizerTest {
             new Locale("", "");
             new Locale("", "", "");
             new Thread().getId();
+        }
+    }
+
+    private static class Java24Violations {
+        private static void method() throws Exception {
+            new StringReader("");
         }
     }
 


### PR DESCRIPTION
Java 24 provides [Reader.of(CharSequence)](https://download.java.net/java/early_access/jdk24/docs/api/java.base/java/io/Reader.html#of(java.lang.CharSequence)).

It is preferrable over `StringReader`, as the API notes says:
>[Reader.of(CharSequence)](https://download.java.net/java/early_access/jdk24/docs/api/java.base/java/io/Reader.html#of(java.lang.CharSequence)) provides a method to read from any [CharSequence](https://download.java.net/java/early_access/jdk24/docs/api/java.base/java/lang/CharSequence.html) that may be more efficient than StringReader.

*Disclaimer: I am the original author of `Reader.of(CharSequence)`. My intention of the current PR is to evangelize its use, so applications will run more efficient.*