### PR TITLE
Add violations for File, Paths, FileInputStream, FileOutputStream, FileReader and FileWriter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '11' ]
         maven: [ '3.6.3', '3.8.8', '3.9.6' ]
     steps:
     - uses: actions/checkout@v4

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1194,6 +1194,30 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>java/io/File."&lt;init&gt;":(Ljava/io/File;Ljava/lang/String;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Path.resolve(String)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/File."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Paths.get(String)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/File."&lt;init&gt;":(Ljava/lang/String;Ljava/lang/String;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Paths.get(String, String...)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/File."&lt;init&gt;":(Ljava/net/URI;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Paths.get(URI)</comment>
+  </violation>
+
+  <violation>
     <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;)V</name>
     <version>11</version>
     <comment>Prefer java.io.FileReader.&lt;init&gt;(File, Charset)</comment>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -552,6 +552,18 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>java/nio/file/Paths.get:(Ljava/lang/String;[Ljava/lang/String;)Ljava/nio/file/Path;</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Path.of(String, String...)</comment>
+  </violation>
+
+  <violation>
+    <name>java/nio/file/Paths.get:(Ljava/net/URI;)Ljava/nio/file/Path;</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Path.of(URI)</comment>
+  </violation>
+
+  <violation>
     <name>java/util/Collections.EMPTY_LIST:Ljava/util/List;</name>
     <version>5</version>
     <comment>Prefer java.util.Collections.emptyList()</comment>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1278,13 +1278,13 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
-    <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;Ljava/nio/Charset;)V</name>
+    <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;Ljava/nio/charset/Charset;)V</name>
     <version>11</version>
     <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(Path, Charset)</comment>
   </violation>
 
   <violation>
-    <name>java/io/FileReader."&lt;init&gt;":(Ljava/lang/String;Ljava/nio/Charset;)V</name>
+    <name>java/io/FileReader."&lt;init&gt;":(Ljava/lang/String;Ljava/nio/charset/Charset;)V</name>
     <version>11</version>
     <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(Paths.get(String), Charset)</comment>
   </violation>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1291,6 +1291,30 @@ violation names use the same format that javap emits.
 
   <violation>
     <name>java/io/FileWriter."&lt;init&gt;":(Ljava/io/File;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Path)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/io/File;Z)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Path, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Paths.get(String))</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;Z)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Paths.get(String), java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/io/File;)V</name>
     <version>11</version>
     <comment>Prefer java.io.FileWriter.&lt;init&gt;(File, Charset)</comment>
   </violation>
@@ -1311,6 +1335,30 @@ violation names use the same format that javap emits.
     <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;Z)V</name>
     <version>11</version>
     <comment>Prefer java.io.FileWriter.&lt;init&gt;(String, Charset, boolean)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/io/File;Ljava/nio/charset/Charset;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Path, Charset)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/io/File;Ljava/nio/charset/Charset;Z)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Path, Charset, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;Ljava/nio/charset/Charset;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Paths.get(String), Charset)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;Ljava/nio/charset/Charset;Z)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Paths.get(String), Charset, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)</comment>
   </violation>
 
     <violation>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1267,6 +1267,18 @@ violation names use the same format that javap emits.
 
   <violation>
     <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(java.nio.file.Path)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileReader."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(java.nio.file.Paths.get(String))</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;)V</name>
     <version>11</version>
     <comment>Prefer java.io.FileReader.&lt;init&gt;(File, Charset)</comment>
   </violation>
@@ -1275,6 +1287,18 @@ violation names use the same format that javap emits.
     <name>java/io/FileReader."&lt;init&gt;":(Ljava/lang/String;)V</name>
     <version>11</version>
     <comment>Prefer java.io.FileReader.&lt;init&gt;(String, Charset)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;Ljava/nio/Charset;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(Path, Charset)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileReader."&lt;init&gt;":(Ljava/lang/String;Ljava/nio/Charset;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(Paths.get(String), Charset)</comment>
   </violation>
 
   <violation>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1278,18 +1278,6 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
-    <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;)V</name>
-    <version>11</version>
-    <comment>Prefer java.io.FileReader.&lt;init&gt;(File, Charset)</comment>
-  </violation>
-
-  <violation>
-    <name>java/io/FileReader."&lt;init&gt;":(Ljava/lang/String;)V</name>
-    <version>11</version>
-    <comment>Prefer java.io.FileReader.&lt;init&gt;(String, Charset)</comment>
-  </violation>
-
-  <violation>
     <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;Ljava/nio/Charset;)V</name>
     <version>11</version>
     <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(Path, Charset)</comment>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1314,30 +1314,6 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
-    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/io/File;)V</name>
-    <version>11</version>
-    <comment>Prefer java.io.FileWriter.&lt;init&gt;(File, Charset)</comment>
-  </violation>
-
-  <violation>
-    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/io/File;Z)V</name>
-    <version>11</version>
-    <comment>Prefer java.io.FileWriter.&lt;init&gt;(File, Charset, boolean)</comment>
-  </violation>
-
-  <violation>
-    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;)V</name>
-    <version>11</version>
-    <comment>Prefer java.io.FileWriter.&lt;init&gt;(String, Charset)</comment>
-  </violation>
-
-  <violation>
-    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;Z)V</name>
-    <version>11</version>
-    <comment>Prefer java.io.FileWriter.&lt;init&gt;(String, Charset, boolean)</comment>
-  </violation>
-
-  <violation>
     <name>java/io/FileWriter."&lt;init&gt;":(Ljava/io/File;Ljava/nio/charset/Charset;)V</name>
     <version>11</version>
     <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Path, Charset)</comment>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1230,6 +1230,18 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>java/io/FileInputStream."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newInputStream(java.nio.file.Paths.get(String))</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileInputStream."&lt;init&gt;":(Ljava/io/File;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newInputStream(java.nio.file.Path)</comment>
+  </violation>
+
+  <violation>
     <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;)V</name>
     <version>11</version>
     <comment>Prefer java.io.FileReader.&lt;init&gt;(File, Charset)</comment>

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1242,6 +1242,30 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>java/io/FileOutputStream."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newOutputStream(java.nio.file.Paths.get(String))</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileOutputStream."&lt;init&gt;":(Ljava/lang/String;Z)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newOutputStream(java.nio.file.Paths.get(String), java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.CREATE)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileOutputStream."&lt;init&gt;":(Ljava/io/File;)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newOutputStream(java.nio.file.Path)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileOutputStream."&lt;init&gt;":(Ljava/io/File;Z)V</name>
+    <version>7</version>
+    <comment>Prefer java.nio.file.Files.newOutputStream(java.nio.file.Path, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.CREATE)</comment>
+  </violation>
+
+  <violation>
     <name>java/io/FileReader."&lt;init&gt;":(Ljava/io/File;)V</name>
     <version>11</version>
     <comment>Prefer java.io.FileReader.&lt;init&gt;(File, Charset)</comment>

--- a/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.InputStream;
@@ -31,12 +33,14 @@ import java.io.PrintWriter;
 import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.NetworkInterface;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -802,6 +806,22 @@ public final class ModernizerTest {
             new Scanner((Path) null, "");
             new Scanner((ReadableByteChannel) null, "");
             Optional.empty().get();
+            new File(new File(""), "");
+            new File("");
+            new File("", "");
+            new File(URI.create("file://name"));
+            new FileInputStream("");
+            new FileInputStream(new File(""));
+            new FileOutputStream("");
+            new FileOutputStream("", true);
+            new FileOutputStream(new File(""));
+            new FileOutputStream(new File(""), true);
+            new FileReader((File) null);
+            new FileReader((String) null);
+            new FileWriter((File) null);
+            new FileWriter((File) null, true);
+            new FileWriter("");
+            new FileWriter("", true);
         }
     }
 
@@ -812,12 +832,14 @@ public final class ModernizerTest {
             CharStreams.nullWriter();
             Files.toString((File) null, (Charset) null);
             Files.write("", (File) null, (Charset) null);
-            new FileReader((File) null);
-            new FileReader((String) null);
-            new FileWriter((File) null);
-            new FileWriter((File) null, true);
-            new FileWriter("");
-            new FileWriter("", true);
+            new FileReader((File) null, (Charset) null);
+            new FileReader((String) null, (Charset) null);
+            new FileWriter((File) null, (Charset) null);
+            new FileWriter((File) null, (Charset) null, true);
+            new FileWriter("", (Charset) null);
+            new FileWriter("", (Charset) null, true);
+            Paths.get(URI.create("file://name"));
+            Paths.get("", "");
         }
     }
 


### PR DESCRIPTION
Modern applications should switch from NIO API to NIO2 API to allow for improved performance.

*Disclaimer: I am part of the I/O performance optimization team at OpenJDK. My intention of the current PR is to evangelize its use, so applications will run more efficient.*