### PR TITLE
Optional <until> element ignores violations since a specific Java version

### DIFF
--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/Modernizer.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/Modernizer.java
@@ -18,9 +18,11 @@ package org.gaul.modernizer_maven_plugin;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -38,14 +40,14 @@ import org.xml.sax.SAXException;
 
 public final class Modernizer {
     private final long javaVersion;
-    private final Map<String, Violation> violations;
+    private final Map<String, Collection<Violation>> violations;
     private final Collection<String> exclusions;
     private final Collection<Pattern> exclusionPatterns;
     private final Collection<String> ignorePackages;
     private final Set<String> ignoreClassNames;
     private final Collection<Pattern> ignoreFullClassNamePatterns;
 
-    public Modernizer(String javaVersion, Map<String, Violation> violations,
+    public Modernizer(String javaVersion, Map<String, Collection<Violation>> violations,
             Collection<String> exclusions,
             Collection<Pattern> exclusionPatterns,
             Collection<String> ignorePackages,
@@ -82,10 +84,10 @@ public final class Modernizer {
         return check(new ClassReader(is));
     }
 
-    public static Map<String, Violation> parseFromXml(InputStream is)
+    public static Map<String, Collection<Violation>> parseFromXml(InputStream is)
             throws IOException, ParserConfigurationException, SAXException {
-        Map<String, Violation> map =
-                new HashMap<String, Violation>();
+        Map<String, Collection<Violation>> map =
+                new HashMap<String, Collection<Violation>>();
         DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
         dbFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
@@ -101,21 +103,24 @@ public final class Modernizer {
             Element element = (Element) nNode;
             String version = element.getElementsByTagName("version").item(0)
                     .getTextContent();
-            int versionNum;
-            if (version.startsWith("1.")) {
-                versionNum = Integer.parseInt(version.substring(2));
-            } else {
-                versionNum = Integer.parseInt(version);
-            }
+            int versionNum = parseVersion(version);
+            Node until = element.getElementsByTagName("until").item(0);
+            OptionalInt versionLimitNum = until == null ? OptionalInt.empty() : OptionalInt.of(parseVersion(until.getTextContent()));
             Violation violation = new Violation(
                     element.getElementsByTagName("name").item(0)
                             .getTextContent(),
                     versionNum,
+                    versionLimitNum,
                     element.getElementsByTagName("comment").item(0)
                             .getTextContent());
-            map.put(violation.getName(), violation);
+            map.computeIfAbsent(violation.getName(), k -> new ArrayList<>()).add(violation);
         }
 
         return map;
+    }
+
+    private static int parseVersion(final String version) {
+        return Integer.parseInt(
+                version.startsWith("1.") ? version.substring(2) : version);
     }
 }

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerClassVisitor.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerClassVisitor.java
@@ -34,7 +34,7 @@ import org.objectweb.asm.commons.InstructionAdapter;
 
 final class ModernizerClassVisitor extends ClassVisitor {
     private final long javaVersion;
-    private final Map<String, Violation> violations;
+    private final Map<String, Collection<Violation>> violations;
     private final Collection<String> exclusions;
     private final Collection<Pattern> exclusionPatterns;
     private final Collection<String> ignorePackages;
@@ -46,7 +46,7 @@ final class ModernizerClassVisitor extends ClassVisitor {
     private String className;
 
     ModernizerClassVisitor(long javaVersion,
-            Map<String, Violation> violations, Collection<String> exclusions,
+            Map<String, Collection<Violation>> violations, Collection<String> exclusions,
             Collection<Pattern> exclusionPatterns,
             Collection<String> ignorePackages,
             Set<String> ignoreClassNames,
@@ -77,8 +77,7 @@ final class ModernizerClassVisitor extends ClassVisitor {
             return;
         }
         for (String itr : interfaces) {
-            Violation violation = violations.get(itr);
-            checkToken(itr, violation, name, /*lineNumber=*/ -1);
+            checkToken(itr, violations.get(itr), name, /*lineNumber=*/ -1);
         }
     }
 
@@ -117,8 +116,7 @@ final class ModernizerClassVisitor extends ClassVisitor {
                     .equals(SuppressModernizer.class.getName());
 
                 String name = Type.getType(desc).getInternalName();
-                Violation violation = violations.get(name);
-                checkToken(name, violation, name, lineNumber);
+                checkToken(name, violations.get(name), name, lineNumber);
 
                 return super.visitAnnotation(desc, visible);
             }
@@ -126,8 +124,7 @@ final class ModernizerClassVisitor extends ClassVisitor {
             private void visitFieldOrMethod(String owner, String name,
                     String desc) {
                 String token = owner + "." + name + ":" + desc;
-                Violation violation = violations.get(token);
-                checkToken(token, violation, name, lineNumber);
+                checkToken(token, violations.get(token), name, lineNumber);
             }
 
             @Override
@@ -137,7 +134,7 @@ final class ModernizerClassVisitor extends ClassVisitor {
 
             private void checkToken(
                 String token,
-                Violation violation,
+                Collection<Violation> v,
                 String name,
                 int lineNumber
             ) {
@@ -145,7 +142,7 @@ final class ModernizerClassVisitor extends ClassVisitor {
                     return;
                 } else {
                     ModernizerClassVisitor.this
-                        .checkToken(token, violation, name, lineNumber);
+                        .checkToken(token, v, name, lineNumber);
                 }
 
             }
@@ -153,11 +150,9 @@ final class ModernizerClassVisitor extends ClassVisitor {
         return adapter;
     }
 
-    private void checkToken(String token, Violation violation, String name,
+    private void checkToken(String token, Collection<Violation> v, String name,
             int lineNumber) {
-        if (violation != null && !exclusions.contains(token) &&
-                javaVersion >= violation.getVersion() &&
-                !ignorePackages.contains(packageName)) {
+        if (v != null && !exclusions.contains(token)) {
             if (ignoreClass()) {
                 return;
             }
@@ -171,8 +166,16 @@ final class ModernizerClassVisitor extends ClassVisitor {
                     return;
                 }
             }
-            occurrences.add(new ViolationOccurrence(name, lineNumber,
-                    violation));
+
+            for (Violation violation : v) {
+                if (javaVersion >= violation.getVersion() &&
+                        (!violation.getUntil().isPresent() ||
+                        javaVersion < violation.getUntil().getAsInt()) &&
+                        !ignorePackages.contains(packageName)) {
+                    occurrences.add(new ViolationOccurrence(name, lineNumber,
+                            violation));
+                }
+            }
         }
     }
 

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
@@ -229,7 +229,7 @@ public final class ModernizerMojo extends AbstractMojo {
                     "javaVersion is not set but is required for execution.");
         }
 
-        Map<String, Violation> allViolations = parseViolations(violationsFile);
+        Map<String, Collection<Violation>> allViolations = parseViolations(violationsFile);
         for (String violationsFilePath : violationsFiles) {
             allViolations.putAll(parseViolations(violationsFilePath));
         }
@@ -328,7 +328,7 @@ public final class ModernizerMojo extends AbstractMojo {
         }
     }
 
-    private static Map<String, Violation> parseViolations(
+    private static Map<String, Collection<Violation>> parseViolations(
             String violationsFilePath) throws MojoExecutionException {
         InputStream is;
         if (violationsFilePath.startsWith(CLASSPATH_PREFIX)) {

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/Violation.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/Violation.java
@@ -16,15 +16,19 @@
 
 package org.gaul.modernizer_maven_plugin;
 
+import java.util.OptionalInt;
+
 public final class Violation {
     private final String name;
     private final int version;
+    private final OptionalInt until; // ignoring violation since this version
     private final String comment;
 
-    Violation(String name, int version, String comment) {
+    Violation(String name, int version, OptionalInt until, String comment) {
         this.name = Utils.checkNotNull(name);
         Utils.checkArgument(version >= 0);
         this.version = version;
+        this.until = Utils.checkNotNull(until);
         this.comment = Utils.checkNotNull(comment);
     }
 
@@ -36,12 +40,16 @@ public final class Violation {
         return version;
     }
 
+    public OptionalInt getUntil() {
+        return until;
+    }
+
     public String getComment() {
         return comment;
     }
 
     @Override
     public String toString() {
-        return name + " " + version + " " + comment;
+        return name + " " + version + (until.isPresent() ? " " + until.getAsInt() : "") + " " + comment;
     }
 }

--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -1298,25 +1298,53 @@ violation names use the same format that javap emits.
   <violation>
     <name>java/io/File."&lt;init&gt;":(Ljava/lang/String;)V</name>
     <version>7</version>
+    <until>11</until>
     <comment>Prefer java.nio.file.Paths.get(String)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/File."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Path.of(String)</comment>
   </violation>
 
   <violation>
     <name>java/io/File."&lt;init&gt;":(Ljava/lang/String;Ljava/lang/String;)V</name>
     <version>7</version>
+    <until>11</until>
     <comment>Prefer java.nio.file.Paths.get(String, String...)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/File."&lt;init&gt;":(Ljava/lang/String;Ljava/lang/String;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Path.of(String, String...)</comment>
   </violation>
 
   <violation>
     <name>java/io/File."&lt;init&gt;":(Ljava/net/URI;)V</name>
     <version>7</version>
+    <until>11</until>
     <comment>Prefer java.nio.file.Paths.get(URI)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/File."&lt;init&gt;":(Ljava/net/URI;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Path.of(URI)</comment>
   </violation>
 
   <violation>
     <name>java/io/FileInputStream."&lt;init&gt;":(Ljava/lang/String;)V</name>
     <version>7</version>
+    <until>11</until>
     <comment>Prefer java.nio.file.Files.newInputStream(java.nio.file.Paths.get(String))</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileInputStream."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newInputStream(java.nio.file.Path.of(String))</comment>
   </violation>
 
   <violation>
@@ -1328,13 +1356,27 @@ violation names use the same format that javap emits.
   <violation>
     <name>java/io/FileOutputStream."&lt;init&gt;":(Ljava/lang/String;)V</name>
     <version>7</version>
+    <until>11</until>
     <comment>Prefer java.nio.file.Files.newOutputStream(java.nio.file.Paths.get(String))</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileOutputStream."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newOutputStream(Path.of(String))</comment>
   </violation>
 
   <violation>
     <name>java/io/FileOutputStream."&lt;init&gt;":(Ljava/lang/String;Z)V</name>
     <version>7</version>
+    <until>11</until>
     <comment>Prefer java.nio.file.Files.newOutputStream(java.nio.file.Paths.get(String), CREATE, APPEND, WRITE)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileOutputStream."&lt;init&gt;":(Ljava/lang/String;Z)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newOutputStream(Path.of(String), CREATE, APPEND, WRITE)</comment>
   </violation>
 
   <violation>
@@ -1358,7 +1400,14 @@ violation names use the same format that javap emits.
   <violation>
     <name>java/io/FileReader."&lt;init&gt;":(Ljava/lang/String;)V</name>
     <version>7</version>
+    <until>11</until>
     <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(java.nio.file.Paths.get(String))</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileReader."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(Path.of(String))</comment>
   </violation>
 
   <violation>
@@ -1370,7 +1419,7 @@ violation names use the same format that javap emits.
   <violation>
     <name>java/io/FileReader."&lt;init&gt;":(Ljava/lang/String;Ljava/nio/charset/Charset;)V</name>
     <version>11</version>
-    <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(Paths.get(String), Charset)</comment>
+    <comment>Prefer java.nio.file.Files.newBufferedReader.&lt;init&gt;(Path.of(String), Charset)</comment>
   </violation>
 
   <violation>
@@ -1388,13 +1437,27 @@ violation names use the same format that javap emits.
   <violation>
     <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;)V</name>
     <version>7</version>
+    <until>11</until>
     <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Paths.get(String))</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Path.of(String))</comment>
   </violation>
 
   <violation>
     <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;Z)V</name>
     <version>7</version>
+    <until>11</until>
     <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Paths.get(String), java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)</comment>
+  </violation>
+
+  <violation>
+    <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;Z)V</name>
+    <version>11</version>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Path.of(String), CREATE, WRITE)</comment>
   </violation>
 
   <violation>
@@ -1412,13 +1475,13 @@ violation names use the same format that javap emits.
   <violation>
     <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;Ljava/nio/charset/Charset;)V</name>
     <version>11</version>
-    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Paths.get(String), Charset)</comment>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Path.of(String), Charset)</comment>
   </violation>
 
   <violation>
     <name>java/io/FileWriter."&lt;init&gt;":(Ljava/lang/String;Ljava/nio/charset/Charset;Z)V</name>
     <version>11</version>
-    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Paths.get(String), Charset, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)</comment>
+    <comment>Prefer java.nio.file.Files.newBufferedWriter.&lt;init&gt;(Path.of(String), Charset, java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.WRITE)</comment>
   </violation>
 
     <violation>

--- a/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -64,6 +64,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.Vector;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
@@ -120,7 +121,7 @@ import org.objectweb.asm.ClassReader;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public final class ModernizerTest {
-    private Map<String, Violation> violations;
+    private Map<String, Collection<Violation>> violations;
     private static final Collection<String> NO_EXCLUSIONS =
             Collections.<String>emptySet();
     private static final Collection<Pattern> NO_EXCLUSION_PATTERNS =
@@ -142,7 +143,7 @@ public final class ModernizerTest {
     public void readsOldJavaVersionFormat() throws Exception {
         try (InputStream is = Modernizer.class.getResourceAsStream(
                 "/modernizer-old-versions.xml")) {
-            Map<String, Violation> old = Modernizer.parseFromXml(is);
+            Map<String, Collection<Violation>> old = Modernizer.parseFromXml(is);
             assertThat(old).hasSize(1);
         }
     }
@@ -387,9 +388,9 @@ public final class ModernizerTest {
     @Test
     public void testAnnotationViolation() throws Exception {
         String name = TestAnnotation.class.getName().replace('.', '/');
-        Map<String, Violation> testViolations = Maps.newHashMap();
+        Map<String, Collection<Violation>> testViolations = Maps.newHashMap();
         testViolations.put(name,
-                new Violation(name, 5, ""));
+                Collections.singleton(new Violation(name, 5, OptionalInt.empty(), "")));
         Modernizer modernizer = new Modernizer("1.5", testViolations,
                 NO_EXCLUSIONS, NO_EXCLUSION_PATTERNS, NO_IGNORED_PACKAGES,
                 NO_IGNORED_CLASS_NAMES, NO_EXCLUSION_PATTERNS);
@@ -402,8 +403,23 @@ public final class ModernizerTest {
     }
 
     @Test
+    public void testUntil() throws Exception {
+        ClassReader cr = new ClassReader(UntilTest.class.getName());
+        Collection<ViolationOccurrence> occurrences = createModernizer("10").check(cr);
+        assertThat(occurrences).hasSize(1);
+        assertThat(occurrences.iterator().next().getViolation().getComment())
+                .isEqualTo("Prefer java.nio.file.Files.newInputStream(java.nio.file.Paths.get(String))");
+
+        occurrences = createModernizer("11").check(cr);
+        assertThat(occurrences).hasSize(1);
+        assertThat(occurrences.iterator().next().getViolation().getComment())
+                .isEqualTo("Prefer java.nio.file.Files.newInputStream(java.nio.file.Path.of(String))");
+    }
+
+    @Test
     public void testAllViolations() throws Exception {
-        Modernizer modernizer = createModernizer("24");
+        final int maxVersion = 24;
+        Modernizer modernizer = createModernizer(String.valueOf(maxVersion));
         Collection<ViolationOccurrence> occurrences = modernizer.check(
                 new ClassReader(AllViolations.class.getName()));
         occurrences.addAll(modernizer.check(
@@ -449,7 +465,14 @@ public final class ModernizerTest {
         violations.remove(
                 "sun/misc/BASE64Encoder.encode:([B)Ljava/lang/String;");
 
-        assertThat(actualViolations).containsAll(violations.values());
+        Collection<Violation> expectedViolations = violations.values().stream()
+              .flatMap(Collection::stream)
+              .filter(violation -> !violation.getUntil().isPresent() || violation.getUntil().getAsInt() >= maxVersion)
+              .collect(Collectors.toList());
+
+        assertThat(actualViolations)
+            .usingRecursiveFieldByFieldElementComparatorOnFields("comment", "name", "version", "until")
+            .containsAll(expectedViolations);
     }
 
     @Test
@@ -585,6 +608,12 @@ public final class ModernizerTest {
         @Override
         public Object get() {
             return new Object();
+        }
+    }
+
+    private static class UntilTest {
+        public static void method() throws Exception {
+            new FileInputStream("");
         }
     }
 


### PR DESCRIPTION
This PR introduces a new feature: Ignoring violations past a specific version.

The new, optional XML attribute `<until>` holds a version since when a `<violation>` is to be ignored. *This is straight-forward and aligned with the existing syntax, as `<version>` does exactly the same, but inverse: It ignores violations *prior* to a specific version.*

As a first proof-of-concept, the `modernizer.xml` now has separate proposals for the replacement of `new File(...)`:
* The existing replacements are now limited to be effective **only** within the range of Java 7 (inclusive) to Java 11 (exclusive), proposing the use of `Paths.get(...)`.
* Duplicate violations are now added being effecting since Java 11 (inclusive), proposing the use of `Path.of(...)`.

Closes #303 

Alternatives:
* We could omit the `<until>` element, but instead from a set of *identically named* violations, only apply the one with the highest version within the target version. *This is complex to implement and less flexible, as it prevents the possibility to **intentionally** apply two identially named violations at the same time (I don't know why someone would want that, but I could imagine that there are use cases for this, possibly once we eventually add more functionality besides printing the comment).*
* We could omit the additional violation, but instead add per-version `comment`. *This is less flexible, as it excludes the possibility to exclude violations **in general** - it only changes the comment. If eventually we come up with additional functionality (like rewriting code), we might like to skip the violation in general.*