### PR TITLE
Fix file descriptor leaks

### DIFF
--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/ModernizerMojo.java
@@ -395,10 +395,11 @@ public final class ModernizerMojo extends AbstractMojo {
             return count;
         }
         if (Files.isDirectory(path)) {
-            Stream<Path> stream = Files.list(path);
-            Iterable<Path> children = stream::iterator;
-            for (Path child : children) {
-                count += recurseFiles(path.resolve(child));
+            try (Stream<Path> stream = Files.list(path)) {
+                Iterable<Path> children = stream::iterator;
+                for (Path child : children) {
+                    count += recurseFiles(path.resolve(child));
+                }
             }
         } else if (path.toString().endsWith(".class")) {
             try (InputStream is = Files.newInputStream(path)) {

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/SuppressGeneratedAnnotationDetector.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/SuppressGeneratedAnnotationDetector.java
@@ -74,10 +74,11 @@ public final class SuppressGeneratedAnnotationDetector {
         if (!Files.exists(path)) {
             return;
         } else if (Files.isDirectory(path)) {
-            Stream<Path> stream = Files.list(path);
-            Iterable<Path> children = stream::iterator;
-            for (Path child : children) {
-                detectInternal(path.resolve(child));
+            try (Stream<Path> stream = Files.list(path)) {
+                Iterable<Path> children = stream::iterator;
+                for (Path child : children) {
+                    detectInternal(path.resolve(child));
+                }
             }
         } else if (path.toString().endsWith(".class")) {
             try (InputStream inputStream = Files.newInputStream(path)) {

--- a/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/SuppressModernizerAnnotationDetector.java
+++ b/modernizer-maven-plugin/src/main/java/org/gaul/modernizer_maven_plugin/SuppressModernizerAnnotationDetector.java
@@ -90,10 +90,11 @@ public final class SuppressModernizerAnnotationDetector {
         if (!Files.exists(path)) {
             return;
         } else if (Files.isDirectory(path)) {
-            Stream<Path> stream = Files.list(path);
-            Iterable<Path> children = stream::iterator;
-            for (Path child : children) {
-                detectInternal(path.resolve(child));
+            try (Stream<Path> stream = Files.list(path)) {
+                Iterable<Path> children = stream::iterator;
+                for (Path child : children) {
+                    detectInternal(path.resolve(child));
+                }
             }
         } else if (path.toString().endsWith(".class")) {
             try (InputStream inputStream = Files.newInputStream(path)) {


### PR DESCRIPTION
Files.list() returns a Stream that needs to be closed, otherwise the directory remains open. This can cause file descriptor exhaustion in large projects.