### PR TITLE
Add violations for Collections.emptyList(), Collections.emptyMap() and Collections.emptySet()

### DIFF
--- a/modernizer-maven-plugin/src/main/resources/modernizer.xml
+++ b/modernizer-maven-plugin/src/main/resources/modernizer.xml
@@ -582,6 +582,24 @@ violation names use the same format that javap emits.
   </violation>
 
   <violation>
+    <name>java/util/Collections.emptyList:()Ljava/util/List;</name>
+    <version>9</version>
+    <comment>Prefer java.util.List.of()</comment>
+  </violation>
+
+  <violation>
+    <name>java/util/Collections.emptyMap:()Ljava/util/Map;</name>
+    <version>9</version>
+    <comment>Prefer java.util.Map.of()</comment>
+  </violation>
+
+  <violation>
+    <name>java/util/Collections.emptySet:()Ljava/util/Set;</name>
+    <version>9</version>
+    <comment>Prefer java.util.Set.of()</comment>
+  </violation>
+
+  <violation>
     <name>java/util/Enumeration</name>
     <version>2</version>
     <comment>Prefer java.util.Iterator</comment>

--- a/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
+++ b/modernizer-maven-plugin/src/test/java/org/gaul/modernizer_maven_plugin/ModernizerTest.java
@@ -787,6 +787,9 @@ public final class ModernizerTest {
             new Float((String) null);
             new Integer((String) null);
             new Long((String) null);
+            Collections.emptyList();
+            Collections.emptyMap();
+            Collections.emptySet();
         }
     }
 


### PR DESCRIPTION
Modern applications should switch from `Collections.empty*()` to `*.of()` to allow for improved efficiency.